### PR TITLE
Follow-up: restore `.env.example` and ignore local `.env` files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Required settings
+CATEGORY=AI
+NEWS_API_KEY=your_newsapi_key
+OPENAI_API_KEY=your_openai_api_key
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USERNAME=you@example.com
+SMTP_PASSWORD=your_app_password
+MAIL_TO_ADDRESS=recipient@example.com
+
+# Optional settings
+# MAIL_FROM_ADDRESS=you@example.com
+# DB_PATH=data/app.db
+# LOG_PATH=logs/app.log
+# FETCH_LIMIT=20
+# SELECTION_LIMIT=5
+# SCHEDULE_HOUR=8
+# SCHEDULE_MINUTE=0

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
-.env.example
+# Local environment files
+.env
+.env.*
+!.env.example
+
+# Python cache
+__pycache__/
+*.py[cod]
+
+# Runtime artifacts
+logs/*.log
+data/*.db


### PR DESCRIPTION
### Motivation
- The repo previously ignored and removed the `.env.example` template which makes fresh checkouts fail `get_settings()` with `ConfigurationError` because required env keys are not documented in-repo.
- Keep secrets out of version control while preserving a shareable, versioned configuration template for local development and CI bootstrapping.

### Description
- Added a tracked ` .env.example` file containing required and optional app settings such as `CATEGORY`, `NEWS_API_KEY`, `OPENAI_API_KEY`, SMTP settings, and optional `DB_PATH`/`LOG_PATH`/scheduling values.
- Updated `.gitignore` to ignore local environment files (`.env`, `.env.*`) but explicitly keep `!.env.example` under version control.
- Also added common ignores for Python caches (`__pycache__`, `*.py[cod]`) and runtime artifacts (`logs/*.log`, `data/*.db`).

### Testing
- Ran `python -m compileall app` to verify code still compiles after the change and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3913ae0d08330be8d4f8f70329ecc)