### PR TITLE
building: DB-articles close #9

### DIFF
--- a/app/repositories/article_repository.py
+++ b/app/repositories/article_repository.py
@@ -1,0 +1,177 @@
+"""Repository for articles table access."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
+
+from app.core.exceptions import DatabaseError, NotFoundError
+from app.db.connection import get_connection
+from app.schemas.article import (
+    Article,
+    ArticleFetchResult,
+    SaveArticlesResult,
+    SummaryStatus,
+)
+
+SELECT_ARTICLE_COLUMNS = """
+SELECT
+    id,
+    url,
+    title,
+    description,
+    source_name,
+    published_at,
+    category,
+    summary,
+    summary_status,
+    fetched_at,
+    last_sent_run_id
+FROM articles
+"""
+
+
+class ArticleRepository:
+    def __init__(
+        self,
+        connection_factory: Callable[[], AbstractContextManager[sqlite3.Connection]] = get_connection,
+    ) -> None:
+        self._connection_factory = connection_factory
+
+    def save_articles(self, articles: Sequence[ArticleFetchResult]) -> SaveArticlesResult:
+        if not articles:
+            return SaveArticlesResult(created_count=0, skipped_count=0)
+
+        created_count = 0
+        skipped_count = 0
+
+        try:
+            with self._connection_factory() as connection:
+                for article in articles:
+                    cursor = connection.execute(
+                        """
+                        INSERT OR IGNORE INTO articles (
+                            url,
+                            title,
+                            description,
+                            source_name,
+                            published_at,
+                            category
+                        ) VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            article.url,
+                            article.title,
+                            article.description,
+                            article.source_name,
+                            article.published_at,
+                            article.category,
+                        ),
+                    )
+                    if cursor.rowcount == 1:
+                        created_count += 1
+                    else:
+                        skipped_count += 1
+
+                connection.commit()
+        except sqlite3.Error as exc:
+            raise DatabaseError("記事の保存に失敗しました") from exc
+
+        return SaveArticlesResult(
+            created_count=created_count,
+            skipped_count=skipped_count,
+        )
+
+    def get_recent_articles(self, category: str, limit: int) -> list[Article]:
+        try:
+            with self._connection_factory() as connection:
+                rows = connection.execute(
+                    f"""
+                    {SELECT_ARTICLE_COLUMNS}
+                    WHERE category = ?
+                    ORDER BY published_at DESC, id DESC
+                    LIMIT ?
+                    """,
+                    (category, limit),
+                ).fetchall()
+        except sqlite3.Error as exc:
+            raise DatabaseError("最新記事の取得に失敗しました") from exc
+
+        return [Article.from_row(row) for row in rows]
+
+    def update_summary(
+        self,
+        article_id: int,
+        *,
+        summary: str | None,
+        summary_status: SummaryStatus,
+    ) -> Article:
+        try:
+            with self._connection_factory() as connection:
+                cursor = connection.execute(
+                    """
+                    UPDATE articles
+                    SET
+                        summary = ?,
+                        summary_status = ?,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = ?
+                    """,
+                    (summary, summary_status, article_id),
+                )
+                if cursor.rowcount == 0:
+                    raise NotFoundError("対象の記事が存在しません")
+
+                article = self._get_by_id(connection, article_id)
+                connection.commit()
+        except NotFoundError:
+            raise
+        except sqlite3.Error as exc:
+            raise DatabaseError("記事要約の更新に失敗しました") from exc
+
+        if article is None:
+            raise DatabaseError("更新後の記事取得に失敗しました")
+
+        return article
+
+    def mark_sent(self, article_ids: Sequence[int], run_id: int) -> int:
+        if not article_ids:
+            return 0
+
+        placeholders = ", ".join("?" for _ in article_ids)
+        parameters = [run_id, *article_ids]
+
+        try:
+            with self._connection_factory() as connection:
+                cursor = connection.execute(
+                    f"""
+                    UPDATE articles
+                    SET
+                        last_sent_run_id = ?,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id IN ({placeholders})
+                    """,
+                    parameters,
+                )
+                connection.commit()
+        except sqlite3.Error as exc:
+            raise DatabaseError("配信済み記事の更新に失敗しました") from exc
+
+        return cursor.rowcount
+
+    def _get_by_id(
+        self,
+        connection: sqlite3.Connection,
+        article_id: int,
+    ) -> Article | None:
+        row = connection.execute(
+            f"""
+            {SELECT_ARTICLE_COLUMNS}
+            WHERE id = ?
+            """,
+            (article_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return Article.from_row(row)

--- a/app/schemas/article.py
+++ b/app/schemas/article.py
@@ -1,1 +1,56 @@
 """Article-related schemas."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Literal
+
+SummaryStatus = Literal["pending", "success", "failed"]
+
+
+@dataclass(frozen=True, slots=True)
+class ArticleFetchResult:
+    title: str
+    description: str | None
+    url: str
+    published_at: str
+    source_name: str | None
+    category: str
+
+
+@dataclass(frozen=True, slots=True)
+class Article:
+    article_id: int
+    url: str
+    title: str
+    description: str | None
+    source_name: str | None
+    published_at: str
+    category: str
+    summary: str | None
+    summary_status: SummaryStatus
+    fetched_at: str
+    last_sent_run_id: int | None
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "Article":
+        return cls(
+            article_id=row["id"],
+            url=row["url"],
+            title=row["title"],
+            description=row["description"],
+            source_name=row["source_name"],
+            published_at=row["published_at"],
+            category=row["category"],
+            summary=row["summary"],
+            summary_status=row["summary_status"],
+            fetched_at=row["fetched_at"],
+            last_sent_run_id=row["last_sent_run_id"],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SaveArticlesResult:
+    created_count: int
+    skipped_count: int


### PR DESCRIPTION
## 概要
`articles` テーブル向け Repository / Schema を実装し、ニュース記事データをアプリ側から操作できるようにしました。  
記事保存・重複排除・取得・要約更新・配信済み管理まで対応する永続化レイヤー整備PRです。Issue #9 対応。

## 変更内容

### 実装追加

#### `app/repositories/article_repository.py`

`articles` テーブル専用 Repository を新規追加。

##### 主な機能

- `save_articles(articles)`
  - 記事一覧を一括保存
  - `INSERT OR IGNORE` により URL 重複排除
  - 作成件数 / スキップ件数返却

- `get_recent_articles(category, limit)`
  - カテゴリ別に新着記事取得
  - `published_at DESC` で並び替え

- `update_summary(article_id, ...)`
  - 要約本文更新
  - 要約ステータス更新
  - `updated_at` 更新

- `mark_sent(article_ids, run_id)`
  - 配信対象記事へ `last_sent_run_id` を記録
  - 配信済み件数返却

- `_get_by_id()`
  - 内部取得処理

##### エラーハンドリング

- SQLite例外 → `DatabaseError`
- 対象未存在 → `NotFoundError`

##### 設計ポイント

- `connection_factory` DI対応でテスト容易化
- 共通SELECT句切り出しで保守性向上
- 空配列入力時の早期return対応

---

### スキーマ追加

#### `app/schemas/article.py`

記事関連データモデルを追加。

##### 型定義

- `SummaryStatus`
  - `"pending"`
  - `"success"`
  - `"failed"`

##### データクラス

- `ArticleFetchResult`
  - NewsAPI等から取得した保存前データ

- `Article`
  - DB保存済み記事モデル

- `SaveArticlesResult`
  - 保存結果件数モデル

##### 実装内容

- `@dataclass(frozen=True, slots=True)`
- `Article.from_row()` による DB Row 変換

## 目的
- ニュース記事永続化処理をRepository層へ集約する
- URL重複排除で再取得時の冪等性を担保する
- 要約結果保存と配信管理を可能にする
- 今後の Service 層実装を進めやすくする

## 確認ポイント
- `save_articles()` で新規記事保存できること
- 同一URL再保存時に skipped_count が増えること
- `get_recent_articles()` がカテゴリ別取得できること
- `update_summary()` で本文 / 状態更新できること
- 存在しない article_id 更新時に `NotFoundError` となること
- `mark_sent()` で last_sent_run_id 更新できること

## 注意事項
- `INSERT OR IGNORE` のため、既存記事更新は行いません（タイトル変更等は対象外）
- URLユニーク制約が schema.sql 側で有効である前提です
- 今後テストコード追加推奨です

## 今後の予定
- NewsAPI クライアント実装
- 記事取得 Service 実装
- AI要約 Service 実装
- 配信対象選定ロジック実装
- pytest による Repository テスト追加

Closes #9