### PR TITLE
building:DB-updated_at close #10

### DIFF
--- a/app/repositories/article_repository.py
+++ b/app/repositories/article_repository.py
@@ -27,7 +27,9 @@ SELECT
     summary,
     summary_status,
     fetched_at,
-    last_sent_run_id
+    last_sent_run_id,
+    created_at,
+    updated_at
 FROM articles
 """
 

--- a/app/repositories/digest_run_repository.py
+++ b/app/repositories/digest_run_repository.py
@@ -20,7 +20,9 @@ SELECT
     selected_count,
     summarized_count,
     email_status,
-    error_message
+    error_message,
+    created_at,
+    updated_at
 FROM digest_runs
 """
 

--- a/app/schemas/article.py
+++ b/app/schemas/article.py
@@ -32,6 +32,8 @@ class Article:
     summary_status: SummaryStatus
     fetched_at: str
     last_sent_run_id: int | None
+    created_at: str
+    updated_at: str
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Article":
@@ -47,6 +49,8 @@ class Article:
             summary_status=row["summary_status"],
             fetched_at=row["fetched_at"],
             last_sent_run_id=row["last_sent_run_id"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
         )
 
 

--- a/app/schemas/digest_run.py
+++ b/app/schemas/digest_run.py
@@ -21,6 +21,8 @@ class DigestRun:
     summarized_count: int
     email_status: EmailStatus
     error_message: str | None
+    created_at: str
+    updated_at: str
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "DigestRun":
@@ -34,4 +36,6 @@ class DigestRun:
             summarized_count=row["summarized_count"],
             email_status=row["email_status"],
             error_message=row["error_message"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
         )


### PR DESCRIPTION
## 概要
`articles` / `digest_runs` の Repository と Schema で、`created_at` / `updated_at` を扱えるように修正しました。  
監査系カラムをアプリ側モデルへ反映し、取得データの完全性を上げるための調整PRです。Issue #10 対応。

## 変更内容

### Repository修正

#### `app/repositories/article_repository.py`
`SELECT_ARTICLE_COLUMNS` に以下を追加しました。

- `created_at`
- `updated_at`

これにより、記事取得時に作成日時・更新日時もアプリ側へ返却されます。

#### `app/repositories/digest_run_repository.py`
`SELECT_DIGEST_RUN_COLUMNS` に以下を追加しました。

- `created_at`
- `updated_at`

これにより、実行履歴取得時に作成日時・更新日時も扱えるようになりました。

---

### Schema修正

#### `app/schemas/article.py`

`Article` に以下の属性を追加しました。

- `created_at: str`
- `updated_at: str`

あわせて `from_row()` でもマッピングを追加しています。

#### `app/schemas/digest_run.py`

`DigestRun` に以下の属性を追加しました。

- `created_at: str`
- `updated_at: str`

こちらも `from_row()` にマッピングを追加しています。

## 目的
- DB上に存在する監査項目をアプリ側でも正しく保持する
- 更新日時を使った将来の表示・判定処理に備える
- Repository と Schema の整合性を取る
- 後続のAPI返却値やテストで必要な情報を欠落させないようにする

## 確認ポイント
- `Article.from_row()` で `created_at` / `updated_at` が取得できること
- `DigestRun.from_row()` で `created_at` / `updated_at` が取得できること
- `get_recent_articles()` 返却モデルに監査カラムが入ること
- `get_latest()` / `create_run()` / `update_result()` の返却モデルに監査カラムが入ること

## 補足
- 今回はDBスキーマ自体の変更ではなく、既存カラムをアプリ側で扱うための追従修正です。
- 変更範囲は小さいですが、RepositoryとSchemaの不整合解消として必要な修正です。

Closes #10