### PR TITLE
fix api

### DIFF
--- a/app/clients/news_api_client.py
+++ b/app/clients/news_api_client.py
@@ -13,6 +13,7 @@ from app.schemas.article import ArticleFetchResult
 
 NEWS_API_BASE_URL = "https://api.thenewsapi.com/v1/news/all"
 DEFAULT_TIMEOUT_SECONDS = 10.0
+FREE_PLAN_MAX_PAGE_SIZE = 3
 
 
 class NewsApiClient:
@@ -22,11 +23,13 @@ class NewsApiClient:
         api_key: str,
         base_url: str = NEWS_API_BASE_URL,
         timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        max_page_size: int = FREE_PLAN_MAX_PAGE_SIZE,
         http_client: httpx.Client | None = None,
     ) -> None:
         self._api_key = api_key
         self._base_url = base_url
         self._timeout = timeout
+        self._max_page_size = max_page_size
         self._http_client = http_client
 
     def fetch_news(self, category: str, page_size: int) -> list[ArticleFetchResult]:
@@ -49,10 +52,11 @@ class NewsApiClient:
         ]
 
     def _request(self, *, category: str, page_size: int) -> dict[str, Any]:
+        effective_page_size = min(page_size, self._max_page_size)
         params = {
             "api_token": self._api_key,
             "search": category,
-            "limit": page_size,
+            "limit": effective_page_size,
         }
 
         if self._http_client is not None:

--- a/tests/unit/clients/test_news_api_client.py
+++ b/tests/unit/clients/test_news_api_client.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import httpx
+
+from app.clients.news_api_client import NewsApiClient
+
+
+def test_fetch_news_clamps_limit_to_free_plan_maximum() -> None:
+    recorded_request: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorded_request["limit"] = request.url.params["limit"]
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "title": "AI市場が拡大",
+                        "description": "生成AIの導入が進んでいる。",
+                        "url": "https://example.com/articles/1",
+                        "published_at": "2026-04-25T09:00:00Z",
+                        "source": "Example News",
+                    }
+                ]
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.Client(transport=transport)
+    client = NewsApiClient(api_key="dummy", http_client=http_client)
+
+    results = client.fetch_news("AI", page_size=20)
+
+    assert recorded_request["limit"] == "3"
+    assert len(results) == 1
+    assert results[0].title == "AI市場が拡大"
+    assert results[0].description == "生成AIの導入が進んでいる。"
+
+
+def test_fetch_news_uses_snippet_when_description_is_missing() -> None:
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "title": "AI市場が拡大",
+                        "snippet": "説明文の代替テキスト。",
+                        "url": "https://example.com/articles/1",
+                        "published_at": "2026-04-25T09:00:00Z",
+                        "source": "Example News",
+                    }
+                ]
+            },
+        )
+    )
+    http_client = httpx.Client(transport=transport)
+    client = NewsApiClient(api_key="dummy", http_client=http_client)
+
+    results = client.fetch_news("AI", page_size=1)
+
+    assert results[0].description == "説明文の代替テキスト。"


### PR DESCRIPTION
## 概要
TheNewsAPI クライアントの取得件数制御を修正し、無料プラン上限に合わせて `limit` を最大3件に制限するようにしました。  
あわせて NewsApiClient の単体テストを追加しています。

## 変更内容

### 修正

#### `app/clients/news_api_client.py`
- `FREE_PLAN_MAX_PAGE_SIZE = 3` を追加
- `max_page_size` をコンストラクタ引数に追加
- `fetch_news()` 実行時の `limit` を `min(page_size, max_page_size)` で制御
- TheNewsAPI 無料プラン想定で、過剰な取得リクエストを防止

### テスト追加

#### `tests/unit/clients/test_news_api_client.py`
- `page_size=20` 指定時でも `limit=3` に丸められることを確認
- `description` がない場合に `snippet` を代替利用することを確認
- `httpx.MockTransport` を使い、外部APIを呼ばずにテスト可能な構成を追加

## 目的
- TheNewsAPI 無料枠での利用制限に対応する
- APIリクエスト失敗リスクを下げる
- ニュース取得クライアントの挙動をテストで保証する

## 確認ポイント
- `fetch_news("AI", page_size=20)` 実行時に `limit=3` になること
- `page_size` が3以下の場合は指定値通りになること
- `description` 欠落時に `snippet` が `description` として扱われること
- `pytest tests/unit/clients/test_news_api_client.py` が成功すること

## 補足
- 今回はニュースAPIクライアントの軽微な修正とテスト追加が中心です。
- PRタイトルが `fix api` だと少し抽象的なので、`fix: clamp TheNewsAPI request limit` などに変更するとレビューしやすいです。