### PR TITLE
building-api-smtp close #13

### DIFF
--- a/app/clients/smtp_client.py
+++ b/app/clients/smtp_client.py
@@ -1,0 +1,67 @@
+"""SMTP client for plain text mail delivery."""
+
+from __future__ import annotations
+
+import smtplib
+import socket
+import ssl
+from email.message import EmailMessage
+
+from app.core.exceptions import MailSendError
+
+DEFAULT_TIMEOUT_SECONDS = 20.0
+
+
+class SmtpClient:
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        username: str,
+        password: str,
+        from_address: str,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        smtp_factory: type[smtplib.SMTP] = smtplib.SMTP,
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._username = username
+        self._password = password
+        self._from_address = from_address
+        self._timeout = timeout
+        self._smtp_factory = smtp_factory
+
+    def send(self, subject: str, body: str, to_address: str) -> None:
+        normalized_subject = subject.strip()
+        normalized_body = body.strip()
+        normalized_to_address = to_address.strip()
+
+        if normalized_subject == "":
+            raise MailSendError("メール件名が空です")
+        if normalized_body == "":
+            raise MailSendError("メール本文が空です")
+        if normalized_to_address == "":
+            raise MailSendError("送信先メールアドレスが空です")
+
+        message = EmailMessage()
+        message["From"] = self._from_address
+        message["To"] = normalized_to_address
+        message["Subject"] = normalized_subject
+        message.set_content(normalized_body)
+
+        try:
+            with self._smtp_factory(self._host, self._port, timeout=self._timeout) as smtp:
+                smtp.ehlo()
+                smtp.starttls(context=ssl.create_default_context())
+                smtp.ehlo()
+                smtp.login(self._username, self._password)
+                smtp.send_message(message)
+        except smtplib.SMTPAuthenticationError as exc:
+            raise MailSendError("SMTP 認証に失敗しました") from exc
+        except smtplib.SMTPException as exc:
+            raise MailSendError("SMTP 送信に失敗しました") from exc
+        except (socket.timeout, TimeoutError) as exc:
+            raise MailSendError("SMTP 通信がタイムアウトしました") from exc
+        except OSError as exc:
+            raise MailSendError("SMTP 接続に失敗しました") from exc

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -120,7 +120,7 @@ def get_settings() -> Settings:
     load_dotenv()
 
     category = _normalize_category(_require_env("CATEGORY"))
-    THE_NEWS_API_TOKEN = _require_any_env("THE_NEWS_API_TOKEN", "THE_NEWS_API_TOKEN")
+    THE_NEWS_API_TOKEN = _require_any_env("THE_NEWS_API_TOKEN", "NEWS_API_KEY")
     openai_api_key = _require_env("OPENAI_API_KEY")
     smtp_host = _require_env("SMTP_HOST")
     smtp_port = _parse_int("SMTP_PORT", _require_env("SMTP_PORT"))

--- a/tests/unit/clients/test_smtp_client.py
+++ b/tests/unit/clients/test_smtp_client.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import smtplib
+import socket
+
+import pytest
+
+from app.clients.smtp_client import SmtpClient
+from app.core.exceptions import MailSendError
+
+
+class DummySMTP:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        *,
+        login_error: Exception | None = None,
+        send_error: Exception | None = None,
+        starttls_error: Exception | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.login_error = login_error
+        self.send_error = send_error
+        self.starttls_error = starttls_error
+        self.login_args: tuple[str, str] | None = None
+        self.sent_message = None
+        self.started_tls = False
+
+    def __enter__(self) -> "DummySMTP":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def ehlo(self) -> None:
+        return None
+
+    def starttls(self, *, context) -> None:
+        if self.starttls_error is not None:
+            raise self.starttls_error
+        self.started_tls = True
+
+    def login(self, username: str, password: str) -> None:
+        if self.login_error is not None:
+            raise self.login_error
+        self.login_args = (username, password)
+
+    def send_message(self, message) -> None:
+        if self.send_error is not None:
+            raise self.send_error
+        self.sent_message = message
+
+
+def test_send_delivers_plain_text_mail() -> None:
+    smtp_instances: list[DummySMTP] = []
+
+    def smtp_factory(host: str, port: int, timeout: float | None = None) -> DummySMTP:
+        smtp = DummySMTP(host, port, timeout)
+        smtp_instances.append(smtp)
+        return smtp
+
+    client = SmtpClient(
+        host="smtp.gmail.com",
+        port=587,
+        username="user@example.com",
+        password="app-password",
+        from_address="user@example.com",
+        smtp_factory=smtp_factory,
+    )
+
+    client.send("件名", "本文です", "to@example.com")
+
+    smtp = smtp_instances[0]
+    assert smtp.host == "smtp.gmail.com"
+    assert smtp.port == 587
+    assert smtp.started_tls is True
+    assert smtp.login_args == ("user@example.com", "app-password")
+    assert smtp.sent_message["To"] == "to@example.com"
+    assert smtp.sent_message["Subject"] == "件名"
+    assert "本文です" in smtp.sent_message.get_content()
+
+
+def test_send_raises_when_body_is_empty() -> None:
+    client = SmtpClient(
+        host="smtp.gmail.com",
+        port=587,
+        username="user@example.com",
+        password="app-password",
+        from_address="user@example.com",
+    )
+
+    with pytest.raises(MailSendError, match="本文が空"):
+        client.send("件名", "   ", "to@example.com")
+
+
+def test_send_converts_authentication_error() -> None:
+    def smtp_factory(host: str, port: int, timeout: float | None = None) -> DummySMTP:
+        return DummySMTP(
+            host,
+            port,
+            timeout,
+            login_error=smtplib.SMTPAuthenticationError(535, b"auth failed"),
+        )
+
+    client = SmtpClient(
+        host="smtp.gmail.com",
+        port=587,
+        username="user@example.com",
+        password="wrong-password",
+        from_address="user@example.com",
+        smtp_factory=smtp_factory,
+    )
+
+    with pytest.raises(MailSendError, match="認証に失敗"):
+        client.send("件名", "本文です", "to@example.com")
+
+
+def test_send_converts_timeout_error() -> None:
+    def smtp_factory(host: str, port: int, timeout: float | None = None) -> DummySMTP:
+        return DummySMTP(
+            host,
+            port,
+            timeout,
+            starttls_error=socket.timeout("timed out"),
+        )
+
+    client = SmtpClient(
+        host="smtp.gmail.com",
+        port=587,
+        username="user@example.com",
+        password="app-password",
+        from_address="user@example.com",
+        smtp_factory=smtp_factory,
+    )
+
+    with pytest.raises(MailSendError, match="タイムアウト"):
+        client.send("件名", "本文です", "to@example.com")


### PR DESCRIPTION
## 概要
SMTPによるプレーンテキストメール送信クライアントを実装しました。  
ダイジェストメール配信に必要な送信基盤を追加し、単体テストも整備しています。Issue #13 対応。

## 変更内容

### 新規追加

#### `app/clients/smtp_client.py`
SMTP送信用クライアントを新規実装。

主な実装内容:
- `SmtpClient.send(subject, body, to_address)`
- 件名 / 本文 / 送信先の空文字チェック
- `EmailMessage` によるプレーンテキストメール生成
- SMTP接続
- STARTTLS対応
- SMTPログイン
- メール送信
- 送信失敗時の `MailSendError` 変換
  - SMTP認証エラー
  - SMTP送信エラー
  - タイムアウト
  - 接続エラー

### 設定修正

#### `app/core/config.py`
- `THE_NEWS_API_TOKEN` の互換読込を修正
- `NEWS_API_KEY` もフォールバック候補として読み込めるように変更

### テスト追加

#### `tests/unit/clients/test_smtp_client.py`
SMTPクライアントの単体テストを追加。

確認内容:
- 正常時にプレーンテキストメールを送信できること
- STARTTLS が実行されること
- SMTPログイン情報が渡されること
- 件名 / 本文 / 送信先が正しく設定されること
- 本文空文字時に `MailSendError` となること
- 認証失敗時に `MailSendError` となること
- タイムアウト時に `MailSendError` となること

## 目的
- メール配信機能のClient層を実装する
- ダイジェスト結果をメール送信できる土台を作る
- SMTP障害時の例外処理を統一する
- モック可能な設計にしてテストしやすくする

## 確認ポイント
- `send()` 実行時にSMTP接続・STARTTLS・ログイン・送信が行われること
- 空本文などの不正入力で送信されずエラーになること
- SMTP認証失敗時に `MailSendError` になること
- `pytest tests/unit/clients/test_smtp_client.py` が成功すること

## 補足
- 後続PRでメール本文生成処理、要約結果との連携、ダイジェスト送信Serviceへ接続する想定です。

Closes #13