### PR TITLE
feature-newsService close #15

### DIFF
--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -1,0 +1,42 @@
+"""News fetching business rules."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+from app.schemas.article import ArticleFetchResult
+
+
+class NewsFetcher(Protocol):
+    def fetch_news(self, category: str, page_size: int) -> list[ArticleFetchResult]:
+        ...
+
+
+class NewsService:
+    def __init__(self, news_client: NewsFetcher) -> None:
+        self._news_client = news_client
+
+    def fetch_latest_articles(self, category: str, limit: int) -> list[ArticleFetchResult]:
+        articles = self._news_client.fetch_news(category, limit)
+        return [article for article in articles if self._is_valid_article(article)]
+
+    def _is_valid_article(self, article: ArticleFetchResult) -> bool:
+        if article.title is None or article.url is None or article.published_at is None:
+            return False
+        return self._is_valid_iso8601(article.published_at)
+
+    @staticmethod
+    def _is_valid_iso8601(value: str) -> bool:
+        normalized = value.strip()
+        if normalized == "":
+            return False
+
+        if normalized.endswith("Z"):
+            normalized = f"{normalized[:-1]}+00:00"
+
+        try:
+            datetime.fromisoformat(normalized)
+        except ValueError:
+            return False
+        return True

--- a/tests/unit/services/test_news_service.py
+++ b/tests/unit/services/test_news_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from app.schemas.article import ArticleFetchResult
+from app.services.news_service import NewsService
+
+
+class DummyNewsClient:
+    def __init__(self, articles: list[ArticleFetchResult]) -> None:
+        self.articles = articles
+        self.calls: list[tuple[str, int]] = []
+
+    def fetch_news(self, category: str, page_size: int) -> list[ArticleFetchResult]:
+        self.calls.append((category, page_size))
+        return self.articles
+
+
+def test_fetch_latest_articles_filters_missing_required_fields() -> None:
+    client = DummyNewsClient(
+        [
+            ArticleFetchResult(
+                title="AI市場が拡大",
+                description="生成AIの導入が進んでいる。",
+                url="https://example.com/articles/1",
+                published_at="2026-04-25T09:00:00Z",
+                source_name="Example News",
+                category="AI",
+            ),
+            ArticleFetchResult(
+                title=None,
+                description="タイトル欠落",
+                url="https://example.com/articles/2",
+                published_at="2026-04-25T10:00:00Z",
+                source_name="Example News",
+                category="AI",
+            ),
+            ArticleFetchResult(
+                title="URL欠落",
+                description="URLがない",
+                url=None,
+                published_at="2026-04-25T11:00:00Z",
+                source_name="Example News",
+                category="AI",
+            ),
+            ArticleFetchResult(
+                title="公開日時欠落",
+                description="published_at がない",
+                url="https://example.com/articles/4",
+                published_at=None,
+                source_name="Example News",
+                category="AI",
+            ),
+        ]
+    )
+    service = NewsService(client)
+
+    results = service.fetch_latest_articles("AI", 20)
+
+    assert client.calls == [("AI", 20)]
+    assert len(results) == 1
+    assert results[0].title == "AI市場が拡大"
+
+
+def test_fetch_latest_articles_filters_invalid_published_at() -> None:
+    client = DummyNewsClient(
+        [
+            ArticleFetchResult(
+                title="AI市場が拡大",
+                description="正常記事",
+                url="https://example.com/articles/1",
+                published_at="2026-04-25T09:00:00Z",
+                source_name="Example News",
+                category="AI",
+            ),
+            ArticleFetchResult(
+                title="日時不正",
+                description="日付形式が壊れている",
+                url="https://example.com/articles/2",
+                published_at="not-a-date",
+                source_name="Example News",
+                category="AI",
+            ),
+        ]
+    )
+    service = NewsService(client)
+
+    results = service.fetch_latest_articles("AI", 20)
+
+    assert len(results) == 1
+    assert results[0].published_at == "2026-04-25T09:00:00Z"


### PR DESCRIPTION
## 概要
ニュース取得処理の Service 層を実装しました。  
News API クライアントから取得した記事に対して、必須項目チェックと公開日時バリデーションを行い、有効な記事のみ後続処理へ渡せるようにしています。Issue #15 対応。

## 変更内容

### 新規追加

#### `app/services/news_service.py`
- `NewsService` を追加
- `NewsFetcher` Protocol を定義
- `fetch_latest_articles(category, limit)` を実装
- 必須項目が欠落した記事を除外
  - `title`
  - `url`
  - `published_at`
- `published_at` が ISO8601 形式でない記事を除外
- `Z` 終端のUTC日時にも対応

### テスト追加

#### `tests/unit/services/test_news_service.py`
- 必須項目欠落記事が除外されることを確認
- 不正な `published_at` の記事が除外されることを確認
- 有効な記事のみ返却されることを確認
- NewsClient に `category` / `limit` が正しく渡ることを確認

## 目的
- 外部APIレスポンスの不完全な記事を後続処理へ渡さない
- 記事保存前の最低限の業務バリデーションを Service 層に集約する
- Repository 層へ保存するデータ品質を担保する
- 後続のダイジェスト処理実装に備える

## 確認ポイント
- `fetch_latest_articles()` で有効記事のみ返ること
- `title` / `url` / `published_at` 欠落記事が除外されること
- 不正な日時文字列が除外されること
- `pytest tests/unit/services/test_news_service.py` が成功すること

## 補足
- 今回はニュース取得後のバリデーション Service の追加が中心です。
- 次PRで記事保存 Service や要約 Service と連携して、ダイジェスト実行フローへ組み込む想定です。

Closes #15