### PR TITLE
feature-article-selector close #16

### DIFF
--- a/app/services/article_selector.py
+++ b/app/services/article_selector.py
@@ -1,1 +1,29 @@
 """Article selection logic."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from app.schemas.article import Article
+
+
+class ArticleSelector:
+    def select_top_articles(self, articles: Iterable[Article], limit: int) -> list[Article]:
+        if limit <= 0:
+            return []
+
+        valid_articles = [article for article in articles if article.published_at.strip() != ""]
+        sorted_articles = sorted(
+            valid_articles,
+            key=lambda article: self._parse_published_at(article.published_at),
+            reverse=True,
+        )
+        return sorted_articles[:limit]
+
+    @staticmethod
+    def _parse_published_at(value: str) -> datetime:
+        normalized = value.strip()
+        if normalized.endswith("Z"):
+            normalized = f"{normalized[:-1]}+00:00"
+        return datetime.fromisoformat(normalized)

--- a/tests/unit/services/test_article_selector.py
+++ b/tests/unit/services/test_article_selector.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from app.schemas.article import Article
+from app.services.article_selector import ArticleSelector
+
+
+def build_article(article_id: int, published_at: str, *, category: str = "AI") -> Article:
+    return Article(
+        article_id=article_id,
+        url=f"https://example.com/articles/{article_id}",
+        title=f"記事{article_id}",
+        description=f"説明{article_id}",
+        source_name="Example News",
+        published_at=published_at,
+        category=category,
+        summary=None,
+        summary_status="pending",
+        fetched_at="2026-04-25T00:00:00Z",
+        last_sent_run_id=None,
+        created_at="2026-04-25T00:00:00Z",
+        updated_at="2026-04-25T00:00:00Z",
+    )
+
+
+def test_select_top_articles_returns_latest_five_articles() -> None:
+    selector = ArticleSelector()
+    articles = [
+        build_article(1, "2026-04-25T01:00:00Z"),
+        build_article(2, "2026-04-25T02:00:00Z"),
+        build_article(3, "2026-04-25T03:00:00Z"),
+        build_article(4, "2026-04-25T04:00:00Z"),
+        build_article(5, "2026-04-25T05:00:00Z"),
+        build_article(6, "2026-04-25T06:00:00Z"),
+    ]
+
+    results = selector.select_top_articles(articles, limit=5)
+
+    assert [article.article_id for article in results] == [6, 5, 4, 3, 2]
+
+
+def test_select_top_articles_skips_articles_with_blank_published_at() -> None:
+    selector = ArticleSelector()
+    articles = [
+        build_article(1, "2026-04-25T01:00:00Z"),
+        build_article(2, " "),
+        build_article(3, "2026-04-25T03:00:00Z"),
+    ]
+
+    results = selector.select_top_articles(articles, limit=5)
+
+    assert [article.article_id for article in results] == [3, 1]
+
+
+def test_select_top_articles_returns_empty_when_limit_is_zero() -> None:
+    selector = ArticleSelector()
+    articles = [build_article(1, "2026-04-25T01:00:00Z")]
+
+    results = selector.select_top_articles(articles, limit=0)
+
+    assert results == []


### PR DESCRIPTION
## 概要
記事選定ロジック `ArticleSelector` を実装しました。  
取得済み記事の中から公開日時の新しい順に並べ替え、ダイジェスト配信用の上位記事を選定できるようにしています。Issue #16 対応。

## 変更内容

### 新規追加

#### `app/services/article_selector.py`
- `ArticleSelector` を追加
- `select_top_articles(articles, limit)` を実装
- `published_at` を基準に新しい順でソート
- `limit` 件数まで上位記事を返却
- `published_at` が空文字の記事は除外
- `limit <= 0` の場合は空配列を返却
- ISO8601 + `Z` 終端日時のパースに対応

### テスト追加

#### `tests/unit/services/test_article_selector.py`
- 新しい順に上位5件が返ることを確認
- `published_at` 空文字記事が除外されることを確認
- `limit=0` の場合に空配列となることを確認

## 目的
- ダイジェスト配信用の記事選定責務を Service 層へ分離する
- 最新ニュースを優先して送信できるようにする
- 将来的なスコアリング・重み付け選定の拡張土台を作る
- Digest実行フローへ組み込みやすくする

## 確認ポイント
- `select_top_articles()` で新しい順に返却されること
- 件数制限が正しく効くこと
- 公開日時空文字の記事が除外されること
- `limit <= 0` で空配列になること
- `pytest tests/unit/services/test_article_selector.py` が成功すること

## 補足
- 現時点では単純な公開日時ソートです。
- 今後は要約済み優先、重複テーマ除外、媒体多様性、重要度スコアなどのロジック追加も可能です。

Closes #16