### PR TITLE
feature-summary-service close #17

### DIFF
--- a/app/services/summary_service.py
+++ b/app/services/summary_service.py
@@ -1,1 +1,63 @@
 """Summary generation service."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.core.exceptions import ExternalApiError
+from app.schemas.article import Article
+
+
+class SummaryGenerator(Protocol):
+    def summarize(self, title: str, description: str | None) -> str:
+        ...
+
+
+class SummaryRepository(Protocol):
+    def update_summary(
+        self,
+        article_id: int,
+        *,
+        summary: str | None,
+        summary_status: str,
+    ) -> Article:
+        ...
+
+
+class SummaryService:
+    def __init__(
+        self,
+        *,
+        openai_client: SummaryGenerator,
+        article_repository: SummaryRepository,
+    ) -> None:
+        self._openai_client = openai_client
+        self._article_repository = article_repository
+
+    def summarize_articles(self, run_id: int, articles: list[Article]) -> list[Article]:
+        del run_id
+
+        summarized_articles: list[Article] = []
+
+        for article in articles:
+            if article.title.strip() == "":
+                continue
+
+            try:
+                summary = self._openai_client.summarize(article.title, article.description)
+                updated_article = self._article_repository.update_summary(
+                    article.article_id,
+                    summary=summary,
+                    summary_status="success",
+                )
+            except ExternalApiError:
+                self._article_repository.update_summary(
+                    article.article_id,
+                    summary=None,
+                    summary_status="failed",
+                )
+                continue
+
+            summarized_articles.append(updated_article)
+
+        return summarized_articles

--- a/tests/unit/services/test_summary_service.py
+++ b/tests/unit/services/test_summary_service.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from app.core.exceptions import ExternalApiError
+from app.schemas.article import Article
+from app.services.summary_service import SummaryService
+
+
+def build_article(article_id: int, *, title: str = "記事タイトル", description: str | None = "説明文") -> Article:
+    return Article(
+        article_id=article_id,
+        url=f"https://example.com/articles/{article_id}",
+        title=title,
+        description=description,
+        source_name="Example News",
+        published_at="2026-04-25T09:00:00Z",
+        category="AI",
+        summary=None,
+        summary_status="pending",
+        fetched_at="2026-04-25T00:00:00Z",
+        last_sent_run_id=None,
+        created_at="2026-04-25T00:00:00Z",
+        updated_at="2026-04-25T00:00:00Z",
+    )
+
+
+class DummyOpenAIClient:
+    def __init__(self, responses: dict[int, str | Exception]) -> None:
+        self._responses = responses
+        self.calls: list[tuple[str, str | None]] = []
+
+    def summarize(self, title: str, description: str | None) -> str:
+        self.calls.append((title, description))
+        article_index = len(self.calls)
+        response = self._responses[article_index]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class DummyArticleRepository:
+    def __init__(self, articles: dict[int, Article]) -> None:
+        self._articles = articles
+        self.updates: list[tuple[int, str | None, str]] = []
+
+    def update_summary(
+        self,
+        article_id: int,
+        *,
+        summary: str | None,
+        summary_status: str,
+    ) -> Article:
+        self.updates.append((article_id, summary, summary_status))
+        article = self._articles[article_id]
+        updated_article = Article(
+            article_id=article.article_id,
+            url=article.url,
+            title=article.title,
+            description=article.description,
+            source_name=article.source_name,
+            published_at=article.published_at,
+            category=article.category,
+            summary=summary,
+            summary_status=summary_status,
+            fetched_at=article.fetched_at,
+            last_sent_run_id=article.last_sent_run_id,
+            created_at=article.created_at,
+            updated_at=article.updated_at,
+        )
+        self._articles[article_id] = updated_article
+        return updated_article
+
+
+def test_summarize_articles_marks_success_for_each_successful_article() -> None:
+    articles = [build_article(1), build_article(2), build_article(3)]
+    repository = DummyArticleRepository({article.article_id: article for article in articles})
+    openai_client = DummyOpenAIClient({1: "要約1。要約2。", 2: "要約3。要約4。", 3: "要約5。要約6。"})
+    service = SummaryService(openai_client=openai_client, article_repository=repository)
+
+    results = service.summarize_articles(1, articles)
+
+    assert len(results) == 3
+    assert repository.updates == [
+        (1, "要約1。要約2。", "success"),
+        (2, "要約3。要約4。", "success"),
+        (3, "要約5。要約6。", "success"),
+    ]
+
+
+def test_summarize_articles_continues_when_one_article_fails() -> None:
+    articles = [build_article(1), build_article(2), build_article(3)]
+    repository = DummyArticleRepository({article.article_id: article for article in articles})
+    openai_client = DummyOpenAIClient(
+        {1: "要約1。要約2。", 2: ExternalApiError("failed"), 3: "要約5。要約6。"}
+    )
+    service = SummaryService(openai_client=openai_client, article_repository=repository)
+
+    results = service.summarize_articles(1, articles)
+
+    assert [article.article_id for article in results] == [1, 3]
+    assert repository.updates == [
+        (1, "要約1。要約2。", "success"),
+        (2, None, "failed"),
+        (3, "要約5。要約6。", "success"),
+    ]
+
+
+def test_summarize_articles_uses_title_only_when_description_is_missing() -> None:
+    article = build_article(1, description=None)
+    repository = DummyArticleRepository({1: article})
+    openai_client = DummyOpenAIClient({1: "要約1。要約2。"})
+    service = SummaryService(openai_client=openai_client, article_repository=repository)
+
+    results = service.summarize_articles(1, [article])
+
+    assert len(results) == 1
+    assert openai_client.calls == [("記事タイトル", None)]
+    assert repository.updates == [(1, "要約1。要約2。", "success")]
+
+
+def test_summarize_articles_skips_articles_with_blank_title() -> None:
+    article = build_article(1, title=" ")
+    repository = DummyArticleRepository({1: article})
+    openai_client = DummyOpenAIClient({})
+    service = SummaryService(openai_client=openai_client, article_repository=repository)
+
+    results = service.summarize_articles(1, [article])
+
+    assert results == []
+    assert openai_client.calls == []
+    assert repository.updates == []


### PR DESCRIPTION
## 概要
記事要約処理の Service 層を実装しました。  
OpenAI クライアントで記事要約を生成し、成功 / 失敗結果を `articles` テーブルへ反映できるようにしています。Issue #17 対応。

## 変更内容

### 新規追加

#### `app/services/summary_service.py`
- `SummaryService` を追加
- `SummaryGenerator` Protocol を定義
- `SummaryRepository` Protocol を定義
- `summarize_articles(run_id, articles)` を実装
- 記事ごとに OpenAI 要約を実行
- 要約成功時は `summary_status="success"` で保存
- 要約失敗時は `summary_status="failed"` で保存
- 1件失敗しても後続記事の要約処理を継続
- タイトル空文字の記事はスキップ

### テスト追加

#### `tests/unit/services/test_summary_service.py`
- 全記事の要約成功時に `success` 保存されることを確認
- 一部記事が失敗しても後続処理が継続することを確認
- 説明文なしの記事でも要約されることを確認
- タイトル空文字の記事はスキップされることを確認

## 目的
- AI要約処理を Service 層へ分離する
- OpenAI Client と Article Repository の連携責務を整理する
- 要約失敗時も全体処理を止めず、可能な記事だけ処理できるようにする
- ダイジェスト実行フローへ組み込む準備を進める

## 確認ポイント
- `summarize_articles()` で成功記事のみ返却されること
- 要約成功時に `summary` と `summary_status=success` が保存されること
- 要約失敗時に `summary=None` / `summary_status=failed` が保存されること
- 1件失敗しても次の記事の要約が継続されること
- `pytest tests/unit/services/test_summary_service.py` が成功すること

## 補足
- `run_id` は現時点では未使用ですが、将来的な実行単位ログや履歴連携のために引数として残しています。
- 次PRでメール本文生成・送信処理、またはダイジェスト全体のオーケストレーションへ接続する想定です。

Closes #17