### PR TITLE
feature-mail-service close #18

### DIFF
--- a/app/services/mail_service.py
+++ b/app/services/mail_service.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import date, datetime
 
 from app.clients.smtp_client import SmtpClient
 from app.core.config import Settings
-from app.core.exceptions import ConfigurationError
+from app.core.exceptions import ConfigurationError, MailBuildError
+from app.schemas.article import Article
 
 
 class MailService:
@@ -18,6 +20,37 @@ class MailService:
     ) -> None:
         self._settings = settings
         self._smtp_client_factory = smtp_client_factory
+
+    def build_message(
+        self,
+        articles: list[Article],
+        *,
+        target_date: date | datetime | None = None,
+    ) -> tuple[str, str] | None:
+        if not articles:
+            return None
+
+        resolved_date = self._resolve_target_date(target_date)
+        subject = f"{self._settings.category}ニュースダイジェスト {resolved_date.isoformat()}"
+        if subject.strip() == "":
+            raise MailBuildError("メール件名の生成に失敗しました")
+
+        body_parts: list[str] = []
+        for article in articles:
+            title = article.title.strip()
+            url = article.url.strip()
+            summary = (article.summary or "").strip()
+
+            if title == "" or url == "" or summary == "":
+                raise MailBuildError("メール本文の生成に必要な記事データが不足しています")
+
+            body_parts.append(f"タイトル: {title}\n要約: {summary}\nURL: {url}")
+
+        body = "\n\n".join(body_parts).strip()
+        if body == "":
+            raise MailBuildError("メール本文の生成に失敗しました")
+
+        return subject, body
 
     def send_mail(self, subject: str, body: str) -> None:
         self._validate_smtp_settings()
@@ -41,3 +74,11 @@ class MailService:
         for name, value in required_values.items():
             if value.strip() == "":
                 raise ConfigurationError(f"必須環境変数が未設定です: {name}")
+
+    @staticmethod
+    def _resolve_target_date(value: date | datetime | None) -> date:
+        if value is None:
+            return date.today()
+        if isinstance(value, datetime):
+            return value.date()
+        return value

--- a/tests/unit/services/test_mail_service.py
+++ b/tests/unit/services/test_mail_service.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import date
 
 import pytest
 
 from app.core.config import Settings
-from app.core.exceptions import ConfigurationError
+from app.core.exceptions import ConfigurationError, MailBuildError
+from app.schemas.article import Article
 from app.services.mail_service import MailService
 
 
@@ -32,6 +34,62 @@ def build_settings() -> Settings:
         db_path=__import__("pathlib").Path("/tmp/app.db"),
         log_path=__import__("pathlib").Path("/tmp/app.log"),
     )
+
+
+def build_article(
+    article_id: int,
+    *,
+    title: str = "記事タイトル",
+    summary: str | None = "要約本文です。",
+    url: str = "https://example.com/articles/1",
+) -> Article:
+    return Article(
+        article_id=article_id,
+        url=url,
+        title=title,
+        description="説明文",
+        source_name="Example News",
+        published_at="2026-04-26T09:00:00Z",
+        category="AI",
+        summary=summary,
+        summary_status="success",
+        fetched_at="2026-04-26T09:00:00Z",
+        last_sent_run_id=None,
+        created_at="2026-04-26T09:00:00Z",
+        updated_at="2026-04-26T09:00:00Z",
+    )
+
+
+def test_build_message_returns_subject_and_body() -> None:
+    service = MailService(settings=build_settings())
+
+    message = service.build_message(
+        [build_article(1), build_article(2, title="記事2", summary="要約2です。", url="https://example.com/articles/2")],
+        target_date=date(2026, 4, 26),
+    )
+
+    assert message is not None
+    subject, body = message
+    assert subject == "AIニュースダイジェスト 2026-04-26"
+    assert "タイトル: 記事タイトル" in body
+    assert "要約: 要約本文です。" in body
+    assert "URL: https://example.com/articles/1" in body
+    assert "タイトル: 記事2" in body
+
+
+def test_build_message_returns_none_when_articles_are_empty() -> None:
+    service = MailService(settings=build_settings())
+
+    message = service.build_message([])
+
+    assert message is None
+
+
+def test_build_message_raises_when_required_article_data_is_missing() -> None:
+    service = MailService(settings=build_settings())
+
+    with pytest.raises(MailBuildError, match="記事データが不足"):
+        service.build_message([build_article(1, url=" ")], target_date=date(2026, 4, 26))
 
 
 def test_send_mail_raises_configuration_error_when_smtp_host_is_missing() -> None:


### PR DESCRIPTION
## 概要
メール送信用の本文生成処理を `MailService` に追加しました。  
要約済み記事からダイジェストメールの件名・本文を作成できるようにしています。Issue #18 対応。

## 変更内容

### 実装追加

#### `app/services/mail_service.py`
- `build_message(articles, target_date)` を追加
- 記事が空の場合は `None` を返却
- 件名を `{CATEGORY}ニュースダイジェスト YYYY-MM-DD` 形式で生成
- 本文に以下を含めるよう実装
  - タイトル
  - 要約
  - URL
- `target_date` は `date` / `datetime` / `None` に対応
- `title` / `url` / `summary` が不足している場合は `MailBuildError`
- 既存の `send_mail()` / SMTP設定チェック処理は維持

### テスト追加

#### `tests/unit/services/test_mail_service.py`
- 件名・本文が正しく生成されること
- 複数記事が本文に含まれること
- 記事が空の場合に `None` を返すこと
- 記事データ不足時に `MailBuildError` となること
- SMTP設定不備時の既存エラー挙動も維持されること

## 目的
- 要約済み記事をメール本文へ変換する責務を Service 層に集約する
- SMTP送信前にメール内容の不足を検知する
- ダイジェスト送信フローへ接続できる状態にする

## 確認ポイント
- `build_message()` が件名・本文を返すこと
- 空記事リストでは送信対象なしとして扱えること
- `title` / `url` / `summary` 不足時に `MailBuildError` になること
- `pytest tests/unit/services/test_mail_service.py` が成功すること

## 補足
- 次PRで、記事取得・保存・選定・要約・メール送信をまとめるダイジェスト実行Serviceへ接続する想定です。

Closes #18