### PR TITLE
Preserve run progress counts on failure in RunHistoryService

### DIFF
--- a/app/services/run_history_service.py
+++ b/app/services/run_history_service.py
@@ -52,12 +52,20 @@ class RunHistoryService:
             error_message=None,
         )
 
-    def fail_run(self, run_id: int, error_message: str) -> DigestRun:
+    def fail_run(
+        self,
+        run_id: int,
+        error_message: str,
+        *,
+        fetched_count: int = 0,
+        selected_count: int = 0,
+        summarized_count: int = 0,
+    ) -> DigestRun:
         return self._digest_run_repository.update_result(
             run_id,
-            fetched_count=0,
-            selected_count=0,
-            summarized_count=0,
+            fetched_count=fetched_count,
+            selected_count=selected_count,
+            summarized_count=summarized_count,
             email_status="failed",
             error_message=error_message,
         )

--- a/tests/unit/services/test_run_history_service.py
+++ b/tests/unit/services/test_run_history_service.py
@@ -110,18 +110,24 @@ def test_finish_run_updates_counts_and_email_status() -> None:
     assert run.finished_at == "2026-04-26T09:05:00Z"
 
 
-def test_fail_run_marks_run_as_failed_with_error_message() -> None:
+def test_fail_run_marks_run_as_failed_with_error_message_and_counts() -> None:
     repository = DummyDigestRunRepository()
     service = RunHistoryService(repository)
 
-    run = service.fail_run(1, "ニュース取得に失敗しました")
+    run = service.fail_run(
+        1,
+        "ニュース取得に失敗しました",
+        fetched_count=3,
+        selected_count=2,
+        summarized_count=1,
+    )
 
     assert repository.updated_calls == [
         {
             "run_id": 1,
-            "fetched_count": 0,
-            "selected_count": 0,
-            "summarized_count": 0,
+            "fetched_count": 3,
+            "selected_count": 2,
+            "summarized_count": 1,
             "email_status": "failed",
             "error_message": "ニュース取得に失敗しました",
         }


### PR DESCRIPTION
### Motivation

- A reviewer pointed out that failing a run after partial progress (e.g., fetch/select/summarize completed) should not overwrite persisted counters with zeros, since that makes run history and the latest-run API misleading.

### Description

- Change `RunHistoryService.fail_run` to accept optional progress counters `fetched_count`, `selected_count`, and `summarized_count` (all defaulting to `0`) and pass them to the repository instead of hardcoding zeros.
- Keep backward compatibility by defaulting those parameters to `0` so existing callers are unaffected.
- Update the unit test in `tests/unit/services/test_run_history_service.py` to call `fail_run` with non-zero counts and assert the repository received and returned those values.

### Testing

- Running `pytest -q tests/unit/services/test_run_history_service.py` without `PYTHONPATH` in this environment failed during collection due to module import path (`ModuleNotFoundError: No module named 'app'`).
- Running `PYTHONPATH=. pytest -q tests/unit/services/test_run_history_service.py` executed the updated test suite and passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed957ff6508330b5e99223f9beae2d)