### PR TITLE
[T401] 共通レスポンススキーマ実装

### DIFF
--- a/app/schemas/api.py
+++ b/app/schemas/api.py
@@ -1,1 +1,67 @@
 """Common API schemas."""
+
+from __future__ import annotations
+
+from typing import Generic, Literal, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.digest_run import DigestRun, EmailStatus, TriggeredBy
+
+ResponseDataT = TypeVar("ResponseDataT", bound=BaseModel)
+
+
+class EmptyData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ApiSuccessResponse(BaseModel, Generic[ResponseDataT]):
+    model_config = ConfigDict(extra="forbid")
+
+    success: Literal[True] = True
+    data: ResponseDataT
+    message: str
+
+
+class ApiErrorResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    success: Literal[False] = False
+    error_code: str
+    message: str
+
+
+class HealthCheckData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    app_name: str
+    timestamp: str
+
+
+class DigestRunData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: int
+    triggered_by: TriggeredBy
+    started_at: str
+    finished_at: str | None
+    fetched_count: int
+    selected_count: int
+    summarized_count: int
+    email_status: EmailStatus
+    error_message: str | None
+
+    @classmethod
+    def from_digest_run(cls, digest_run: DigestRun) -> "DigestRunData":
+        return cls(
+            run_id=digest_run.run_id,
+            triggered_by=digest_run.triggered_by,
+            started_at=digest_run.started_at,
+            finished_at=digest_run.finished_at,
+            fetched_count=digest_run.fetched_count,
+            selected_count=digest_run.selected_count,
+            summarized_count=digest_run.summarized_count,
+            email_status=digest_run.email_status,
+            error_message=digest_run.error_message,
+        )

--- a/tests/unit/test_api_schemas.py
+++ b/tests/unit/test_api_schemas.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from app.schemas.api import (
+    ApiErrorResponse,
+    ApiSuccessResponse,
+    DigestRunData,
+    EmptyData,
+    HealthCheckData,
+)
+from app.schemas.digest_run import DigestRun
+
+
+def build_digest_run() -> DigestRun:
+    return DigestRun(
+        run_id=12,
+        triggered_by="manual",
+        started_at="2026-04-18T08:00:00+09:00",
+        finished_at="2026-04-18T08:01:42+09:00",
+        fetched_count=20,
+        selected_count=5,
+        summarized_count=4,
+        email_status="success",
+        error_message=None,
+        created_at="2026-04-18T08:00:00+09:00",
+        updated_at="2026-04-18T08:01:42+09:00",
+    )
+
+
+def test_success_response_wraps_health_check_payload() -> None:
+    response = ApiSuccessResponse[HealthCheckData](
+        data=HealthCheckData(
+            status="ok",
+            app_name="FocusDigest",
+            timestamp="2026-04-18T08:00:00+09:00",
+        ),
+        message="成功",
+    )
+
+    assert response.model_dump() == {
+        "success": True,
+        "data": {
+            "status": "ok",
+            "app_name": "FocusDigest",
+            "timestamp": "2026-04-18T08:00:00+09:00",
+        },
+        "message": "成功",
+    }
+
+
+def test_success_response_allows_empty_object_payload() -> None:
+    response = ApiSuccessResponse[EmptyData](
+        data=EmptyData(),
+        message="成功",
+    )
+
+    assert response.model_dump() == {
+        "success": True,
+        "data": {},
+        "message": "成功",
+    }
+
+
+def test_error_response_matches_api_spec() -> None:
+    response = ApiErrorResponse(
+        error_code="JOB_ALREADY_RUNNING",
+        message="既にジョブ実行中です",
+    )
+
+    assert response.model_dump() == {
+        "success": False,
+        "error_code": "JOB_ALREADY_RUNNING",
+        "message": "既にジョブ実行中です",
+    }
+
+
+def test_digest_run_data_maps_from_domain_schema() -> None:
+    data = DigestRunData.from_digest_run(build_digest_run())
+
+    assert data.model_dump() == {
+        "run_id": 12,
+        "triggered_by": "manual",
+        "started_at": "2026-04-18T08:00:00+09:00",
+        "finished_at": "2026-04-18T08:01:42+09:00",
+        "fetched_count": 20,
+        "selected_count": 5,
+        "summarized_count": 4,
+        "email_status": "success",
+        "error_message": None,
+    }


### PR DESCRIPTION
## 概要
- API仕様書に合わせて成功/失敗の共通レスポンススキーマを追加
- health と digest run のレスポンス DTO を追加
- 共通レスポンス包装と DTO 変換のユニットテストを追加

## テスト
- python3 -m pytest -q tests/unit/test_api_schemas.py
- python3 -m pytest -q tests/unit

close #22