### PR TITLE
[T402] ヘルスチェックAPI実装

### DIFF
--- a/app/api/health.py
+++ b/app/api/health.py
@@ -1,0 +1,23 @@
+"""Health check API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter
+
+from app.schemas.api import ApiSuccessResponse, HealthCheckData
+
+router = APIRouter(prefix="/api/v1", tags=["health"])
+
+
+@router.get("/health", response_model=ApiSuccessResponse[HealthCheckData])
+def get_health() -> ApiSuccessResponse[HealthCheckData]:
+    return ApiSuccessResponse[HealthCheckData](
+        data=HealthCheckData(
+            status="ok",
+            app_name="FocusDigest",
+            timestamp=datetime.now().astimezone().isoformat(),
+        ),
+        message="成功",
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from app.api.health import router as health_router
 from app.core.logging import configure_logging
 from app.db.connection import initialize_database
 
@@ -19,3 +20,4 @@ async def lifespan(_: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+app.include_router(health_router)

--- a/app/schemas/api.py
+++ b/app/schemas/api.py
@@ -1,1 +1,67 @@
 """Common API schemas."""
+
+from __future__ import annotations
+
+from typing import Generic, Literal, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.digest_run import DigestRun, EmailStatus, TriggeredBy
+
+ResponseDataT = TypeVar("ResponseDataT", bound=BaseModel)
+
+
+class EmptyData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ApiSuccessResponse(BaseModel, Generic[ResponseDataT]):
+    model_config = ConfigDict(extra="forbid")
+
+    success: Literal[True] = True
+    data: ResponseDataT
+    message: str
+
+
+class ApiErrorResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    success: Literal[False] = False
+    error_code: str
+    message: str
+
+
+class HealthCheckData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    app_name: str
+    timestamp: str
+
+
+class DigestRunData(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: int
+    triggered_by: TriggeredBy
+    started_at: str
+    finished_at: str | None
+    fetched_count: int
+    selected_count: int
+    summarized_count: int
+    email_status: EmailStatus
+    error_message: str | None
+
+    @classmethod
+    def from_digest_run(cls, digest_run: DigestRun) -> "DigestRunData":
+        return cls(
+            run_id=digest_run.run_id,
+            triggered_by=digest_run.triggered_by,
+            started_at=digest_run.started_at,
+            finished_at=digest_run.finished_at,
+            fetched_count=digest_run.fetched_count,
+            selected_count=digest_run.selected_count,
+            summarized_count=digest_run.summarized_count,
+            email_status=digest_run.email_status,
+            error_message=digest_run.error_message,
+        )

--- a/tests/unit/api/test_health_api.py
+++ b/tests/unit/api/test_health_api.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_get_health_returns_common_success_response() -> None:
+    client = TestClient(app)
+
+    response = client.get("/api/v1/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["message"] == "成功"
+    assert body["data"]["status"] == "ok"
+    assert body["data"]["app_name"] == "FocusDigest"
+    datetime.fromisoformat(body["data"]["timestamp"])


### PR DESCRIPTION
## 概要
- GET /api/v1/health を追加
- FastAPI アプリに health ルーターを登録
- 共通レスポンス形式でヘルスチェックを返す
- health API の単体テストを追加

## テスト
- python3 -m pytest -q tests/unit/api/test_health_api.py
- python3 -m pytest -q tests/unit

close #23