### PR TITLE
[T403] 手動実行API実装

### DIFF
--- a/app/api/digest.py
+++ b/app/api/digest.py
@@ -1,0 +1,76 @@
+"""Digest job APIs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends
+from fastapi.responses import JSONResponse
+
+from app.clients.news_api_client import NewsApiClient
+from app.clients.openai_client import OpenAiClient
+from app.core.config import Settings, get_settings
+from app.core.exceptions import AppError
+from app.repositories.article_repository import ArticleRepository
+from app.repositories.digest_run_repository import DigestRunRepository
+from app.schemas.api import ApiErrorResponse, ApiSuccessResponse, DigestRunData
+from app.services.article_selector import ArticleSelector
+from app.services.digest_service import DigestService
+from app.services.mail_service import MailService
+from app.services.news_service import NewsService
+from app.services.run_history_service import RunHistoryService
+from app.services.summary_service import SummaryService
+
+router = APIRouter(prefix="/api/v1", tags=["digest"])
+
+
+def get_digest_service(settings: Settings = Depends(get_settings)) -> DigestService:
+    article_repository = ArticleRepository()
+
+    return DigestService(
+        settings=settings,
+        news_service=NewsService(NewsApiClient(api_key=settings.THE_NEWS_API_TOKEN)),
+        article_repository=article_repository,
+        article_selector=ArticleSelector(),
+        summary_service=SummaryService(
+            openai_client=OpenAiClient(api_key=settings.openai_api_key),
+            article_repository=article_repository,
+        ),
+        mail_service=MailService(settings=settings),
+        run_history_service=RunHistoryService(DigestRunRepository()),
+    )
+
+
+def _error_response(error: AppError) -> JSONResponse:
+    return JSONResponse(
+        status_code=error.status_code,
+        content=ApiErrorResponse(
+            error_code=error.error_code,
+            message=error.message,
+        ).model_dump(),
+    )
+
+
+@router.post("/jobs/digest/run", response_model=ApiSuccessResponse[DigestRunData])
+def run_digest_job(
+    payload: dict[str, Any] | None = Body(default=None),
+    digest_service: DigestService = Depends(get_digest_service),
+) -> ApiSuccessResponse[DigestRunData] | JSONResponse:
+    if payload not in (None, {}):
+        return JSONResponse(
+            status_code=400,
+            content=ApiErrorResponse(
+                error_code="VALIDATION_ERROR",
+                message="リクエストボディは空または空JSONのみ許可されています",
+            ).model_dump(),
+        )
+
+    try:
+        result = digest_service.run("manual")
+    except AppError as error:
+        return _error_response(error)
+
+    return ApiSuccessResponse[DigestRunData](
+        data=DigestRunData.from_digest_run(result.run),
+        message="ダイジェスト処理が完了しました",
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
+from app.api.digest import router as digest_router
 from app.api.health import router as health_router
+from app.core.exceptions import AppError
 from app.core.logging import configure_logging
 from app.db.connection import initialize_database
+from app.schemas.api import ApiErrorResponse
 
 
 @asynccontextmanager
@@ -21,3 +25,15 @@ async def lifespan(_: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 app.include_router(health_router)
+app.include_router(digest_router)
+
+
+@app.exception_handler(AppError)
+async def handle_app_error(_: Request, error: AppError) -> JSONResponse:
+    return JSONResponse(
+        status_code=error.status_code,
+        content=ApiErrorResponse(
+            error_code=error.error_code,
+            message=error.message,
+        ).model_dump(),
+    )

--- a/tests/unit/api/test_digest_api.py
+++ b/tests/unit/api/test_digest_api.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.api.digest import get_digest_service
+from app.core.config import get_settings
+from app.core.exceptions import ConfigurationError, DatabaseError, JobAlreadyRunningError
+from app.main import app
+from app.schemas.article import SaveArticlesResult
+from app.schemas.digest_run import DigestRun
+from app.services.digest_service import DigestExecutionResult
+
+
+def build_digest_run(*, email_status: str = "success", error_message: str | None = None) -> DigestRun:
+    return DigestRun(
+        run_id=12,
+        triggered_by="manual",
+        started_at="2026-04-18T08:00:00+09:00",
+        finished_at="2026-04-18T08:01:42+09:00",
+        fetched_count=20,
+        selected_count=5,
+        summarized_count=4,
+        email_status=email_status,
+        error_message=error_message,
+        created_at="2026-04-18T08:00:00+09:00",
+        updated_at="2026-04-18T08:01:42+09:00",
+    )
+
+
+class StubDigestService:
+    def __init__(
+        self,
+        *,
+        result: DigestExecutionResult | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self._result = result
+        self._error = error
+        self.calls: list[str] = []
+
+    def run(self, triggered_by: str) -> DigestExecutionResult:
+        self.calls.append(triggered_by)
+        if self._error is not None:
+            raise self._error
+        assert self._result is not None
+        return self._result
+
+
+def build_success_result() -> DigestExecutionResult:
+    digest_run = build_digest_run()
+    return DigestExecutionResult(
+        run=digest_run,
+        saved_articles=SaveArticlesResult(created_count=20, skipped_count=0),
+        selected_articles=[],
+        summarized_articles=[],
+    )
+
+
+def test_run_digest_returns_success_response() -> None:
+    stub_service = StubDigestService(result=build_success_result())
+    app.dependency_overrides[get_digest_service] = lambda: stub_service
+    client = TestClient(app)
+
+    response = client.post("/api/v1/jobs/digest/run")
+
+    assert response.status_code == 200
+    assert stub_service.calls == ["manual"]
+    assert response.json() == {
+        "success": True,
+        "data": {
+            "run_id": 12,
+            "triggered_by": "manual",
+            "started_at": "2026-04-18T08:00:00+09:00",
+            "finished_at": "2026-04-18T08:01:42+09:00",
+            "fetched_count": 20,
+            "selected_count": 5,
+            "summarized_count": 4,
+            "email_status": "success",
+            "error_message": None,
+        },
+        "message": "ダイジェスト処理が完了しました",
+    }
+    app.dependency_overrides.clear()
+
+
+def test_run_digest_accepts_empty_json_body() -> None:
+    stub_service = StubDigestService(result=build_success_result())
+    app.dependency_overrides[get_digest_service] = lambda: stub_service
+    client = TestClient(app)
+
+    response = client.post("/api/v1/jobs/digest/run", json={})
+
+    assert response.status_code == 200
+    assert stub_service.calls == ["manual"]
+    app.dependency_overrides.clear()
+
+
+def test_run_digest_rejects_non_empty_json_body() -> None:
+    stub_service = StubDigestService(result=build_success_result())
+    app.dependency_overrides[get_digest_service] = lambda: stub_service
+    client = TestClient(app)
+
+    response = client.post("/api/v1/jobs/digest/run", json={"unexpected": True})
+
+    assert response.status_code == 400
+    assert stub_service.calls == []
+    assert response.json() == {
+        "success": False,
+        "error_code": "VALIDATION_ERROR",
+        "message": "リクエストボディは空または空JSONのみ許可されています",
+    }
+    app.dependency_overrides.clear()
+
+
+def test_run_digest_returns_400_for_configuration_error() -> None:
+    stub_service = StubDigestService(error=ConfigurationError("必須設定が不足しています"))
+    app.dependency_overrides[get_digest_service] = lambda: stub_service
+    client = TestClient(app)
+
+    response = client.post("/api/v1/jobs/digest/run")
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "success": False,
+        "error_code": "CONFIGURATION_ERROR",
+        "message": "必須設定が不足しています",
+    }
+    app.dependency_overrides.clear()
+
+
+def test_run_digest_returns_400_for_settings_resolution_error() -> None:
+    def raise_configuration_error() -> None:
+        raise ConfigurationError("必須設定が不足しています")
+
+    app.dependency_overrides[get_settings] = raise_configuration_error
+    client = TestClient(app)
+
+    response = client.post("/api/v1/jobs/digest/run")
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "success": False,
+        "error_code": "CONFIGURATION_ERROR",
+        "message": "必須設定が不足しています",
+    }
+    app.dependency_overrides.clear()
+
+
+def test_run_digest_returns_409_for_running_job() -> None:
+    stub_service = StubDigestService(error=JobAlreadyRunningError("ダイジェスト処理は既に実行中です"))
+    app.dependency_overrides[get_digest_service] = lambda: stub_service
+    client = TestClient(app)
+
+    response = client.post("/api/v1/jobs/digest/run")
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "success": False,
+        "error_code": "JOB_ALREADY_RUNNING",
+        "message": "ダイジェスト処理は既に実行中です",
+    }
+    app.dependency_overrides.clear()
+
+
+def test_run_digest_returns_500_for_processing_error() -> None:
+    stub_service = StubDigestService(error=DatabaseError("実行履歴の更新に失敗しました"))
+    app.dependency_overrides[get_digest_service] = lambda: stub_service
+    client = TestClient(app)
+
+    response = client.post("/api/v1/jobs/digest/run")
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "success": False,
+        "error_code": "DATABASE_ERROR",
+        "message": "実行履歴の更新に失敗しました",
+    }
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## 概要
- POST /api/v1/jobs/digest/run を追加
- DigestService の依存組み立てを API 層に追加
- AppError を共通エラーレスポンスへ変換する例外ハンドラを追加
- 手動実行 API の正常系と異常系テストを追加

## テスト
- python3 -m pytest -q tests/unit/api/test_digest_api.py
- python3 -m pytest -q tests/unit

close #24