### PR TITLE
[T404] 最新実行結果API実装

### DIFF
--- a/app/api/digest.py
+++ b/app/api/digest.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 from app.clients.news_api_client import NewsApiClient
 from app.clients.openai_client import OpenAiClient
 from app.core.config import Settings, get_settings
-from app.core.exceptions import AppError
+from app.core.exceptions import AppError, NotFoundError
 from app.repositories.article_repository import ArticleRepository
 from app.repositories.digest_run_repository import DigestRunRepository
 from app.schemas.api import ApiErrorResponse, ApiSuccessResponse, DigestRunData
@@ -22,6 +22,10 @@ from app.services.run_history_service import RunHistoryService
 from app.services.summary_service import SummaryService
 
 router = APIRouter(prefix="/api/v1", tags=["digest"])
+
+
+def get_run_history_service() -> RunHistoryService:
+    return RunHistoryService(DigestRunRepository())
 
 
 def get_digest_service(settings: Settings = Depends(get_settings)) -> DigestService:
@@ -73,4 +77,18 @@ def run_digest_job(
     return ApiSuccessResponse[DigestRunData](
         data=DigestRunData.from_digest_run(result.run),
         message="ダイジェスト処理が完了しました",
+    )
+
+
+@router.get("/jobs/digest/runs/latest", response_model=ApiSuccessResponse[DigestRunData])
+def get_latest_digest_run(
+    run_history_service: RunHistoryService = Depends(get_run_history_service),
+) -> ApiSuccessResponse[DigestRunData]:
+    latest_run = run_history_service.get_latest_run()
+    if latest_run is None:
+        raise NotFoundError("直近の実行履歴が存在しません")
+
+    return ApiSuccessResponse[DigestRunData](
+        data=DigestRunData.from_digest_run(latest_run),
+        message="成功",
     )

--- a/tests/unit/api/test_digest_api.py
+++ b/tests/unit/api/test_digest_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
-from app.api.digest import get_digest_service
+from app.api.digest import get_digest_service, get_run_history_service
 from app.core.config import get_settings
 from app.core.exceptions import ConfigurationError, DatabaseError, JobAlreadyRunningError
 from app.main import app
@@ -44,6 +44,24 @@ class StubDigestService:
             raise self._error
         assert self._result is not None
         return self._result
+
+
+class StubRunHistoryService:
+    def __init__(
+        self,
+        *,
+        latest_run: DigestRun | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self._latest_run = latest_run
+        self._error = error
+        self.calls = 0
+
+    def get_latest_run(self) -> DigestRun | None:
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        return self._latest_run
 
 
 def build_success_result() -> DigestExecutionResult:
@@ -174,5 +192,64 @@ def test_run_digest_returns_500_for_processing_error() -> None:
         "success": False,
         "error_code": "DATABASE_ERROR",
         "message": "実行履歴の更新に失敗しました",
+    }
+    app.dependency_overrides.clear()
+
+
+def test_get_latest_digest_run_returns_success_response() -> None:
+    stub_service = StubRunHistoryService(latest_run=build_digest_run())
+    app.dependency_overrides[get_run_history_service] = lambda: stub_service
+    client = TestClient(app)
+
+    response = client.get("/api/v1/jobs/digest/runs/latest")
+
+    assert response.status_code == 200
+    assert stub_service.calls == 1
+    assert response.json() == {
+        "success": True,
+        "data": {
+            "run_id": 12,
+            "triggered_by": "manual",
+            "started_at": "2026-04-18T08:00:00+09:00",
+            "finished_at": "2026-04-18T08:01:42+09:00",
+            "fetched_count": 20,
+            "selected_count": 5,
+            "summarized_count": 4,
+            "email_status": "success",
+            "error_message": None,
+        },
+        "message": "成功",
+    }
+    app.dependency_overrides.clear()
+
+
+def test_get_latest_digest_run_returns_404_when_no_history_exists() -> None:
+    stub_service = StubRunHistoryService(latest_run=None)
+    app.dependency_overrides[get_run_history_service] = lambda: stub_service
+    client = TestClient(app)
+
+    response = client.get("/api/v1/jobs/digest/runs/latest")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "success": False,
+        "error_code": "NOT_FOUND",
+        "message": "直近の実行履歴が存在しません",
+    }
+    app.dependency_overrides.clear()
+
+
+def test_get_latest_digest_run_returns_500_for_repository_error() -> None:
+    stub_service = StubRunHistoryService(error=DatabaseError("最新の実行履歴の取得に失敗しました"))
+    app.dependency_overrides[get_run_history_service] = lambda: stub_service
+    client = TestClient(app)
+
+    response = client.get("/api/v1/jobs/digest/runs/latest")
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "success": False,
+        "error_code": "DATABASE_ERROR",
+        "message": "最新の実行履歴の取得に失敗しました",
     }
     app.dependency_overrides.clear()


### PR DESCRIPTION
## 概要
- GET /api/v1/jobs/digest/runs/latest を追加
- 最新実行履歴の取得依存を digest API に追加
- 履歴なしの 404 と取得失敗の 500 を API テストで検証

## テスト
- python3 -m pytest -q tests/unit/api/test_digest_api.py
- python3 -m pytest -q tests/unit

close #25