### PR TITLE
[T405] API例外ハンドラ実装

### DIFF
--- a/app/api/digest.py
+++ b/app/api/digest.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, Body, Depends
-from fastapi.responses import JSONResponse
 
 from app.clients.news_api_client import NewsApiClient
 from app.clients.openai_client import OpenAiClient
 from app.core.config import Settings, get_settings
-from app.core.exceptions import AppError, NotFoundError
+from app.core.exceptions import NotFoundError, ValidationError
 from app.repositories.article_repository import ArticleRepository
 from app.repositories.digest_run_repository import DigestRunRepository
-from app.schemas.api import ApiErrorResponse, ApiSuccessResponse, DigestRunData
+from app.schemas.api import ApiSuccessResponse, DigestRunData
 from app.services.article_selector import ArticleSelector
 from app.services.digest_service import DigestService
 from app.services.mail_service import MailService
@@ -43,36 +42,15 @@ def get_digest_service(settings: Settings = Depends(get_settings)) -> DigestServ
         mail_service=MailService(settings=settings),
         run_history_service=RunHistoryService(DigestRunRepository()),
     )
-
-
-def _error_response(error: AppError) -> JSONResponse:
-    return JSONResponse(
-        status_code=error.status_code,
-        content=ApiErrorResponse(
-            error_code=error.error_code,
-            message=error.message,
-        ).model_dump(),
-    )
-
-
 @router.post("/jobs/digest/run", response_model=ApiSuccessResponse[DigestRunData])
 def run_digest_job(
     payload: dict[str, Any] | None = Body(default=None),
     digest_service: DigestService = Depends(get_digest_service),
-) -> ApiSuccessResponse[DigestRunData] | JSONResponse:
+) -> ApiSuccessResponse[DigestRunData]:
     if payload not in (None, {}):
-        return JSONResponse(
-            status_code=400,
-            content=ApiErrorResponse(
-                error_code="VALIDATION_ERROR",
-                message="リクエストボディは空または空JSONのみ許可されています",
-            ).model_dump(),
-        )
+        raise ValidationError("リクエストボディは空または空JSONのみ許可されています")
 
-    try:
-        result = digest_service.run("manual")
-    except AppError as error:
-        return _error_response(error)
+    result = digest_service.run("manual")
 
     return ApiSuccessResponse[DigestRunData](
         data=DigestRunData.from_digest_run(result.run),

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -22,6 +22,13 @@ class ConfigurationError(AppError):
     status_code = 400
 
 
+class ValidationError(AppError):
+    """Raised when API input validation fails."""
+
+    error_code = "VALIDATION_ERROR"
+    status_code = 400
+
+
 class DatabaseError(AppError):
     """Raised when database access fails."""
 

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from app.api.digest import router as digest_router
@@ -35,5 +36,27 @@ async def handle_app_error(_: Request, error: AppError) -> JSONResponse:
         content=ApiErrorResponse(
             error_code=error.error_code,
             message=error.message,
+        ).model_dump(),
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def handle_request_validation_error(_: Request, __: RequestValidationError) -> JSONResponse:
+    return JSONResponse(
+        status_code=400,
+        content=ApiErrorResponse(
+            error_code="VALIDATION_ERROR",
+            message="入力値が不正です",
+        ).model_dump(),
+    )
+
+
+@app.exception_handler(Exception)
+async def handle_unexpected_error(_: Request, __: Exception) -> JSONResponse:
+    return JSONResponse(
+        status_code=500,
+        content=ApiErrorResponse(
+            error_code="INTERNAL_SERVER_ERROR",
+            message="サーバー内部エラーが発生しました",
         ).model_dump(),
     )

--- a/tests/unit/api/test_digest_api.py
+++ b/tests/unit/api/test_digest_api.py
@@ -196,6 +196,38 @@ def test_run_digest_returns_500_for_processing_error() -> None:
     app.dependency_overrides.clear()
 
 
+def test_run_digest_returns_400_for_request_validation_error() -> None:
+    stub_service = StubDigestService(result=build_success_result())
+    app.dependency_overrides[get_digest_service] = lambda: stub_service
+    client = TestClient(app)
+
+    response = client.post("/api/v1/jobs/digest/run", json=[])
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "success": False,
+        "error_code": "VALIDATION_ERROR",
+        "message": "入力値が不正です",
+    }
+    app.dependency_overrides.clear()
+
+
+def test_run_digest_returns_500_for_unexpected_error() -> None:
+    stub_service = StubDigestService(error=RuntimeError("unexpected"))
+    app.dependency_overrides[get_digest_service] = lambda: stub_service
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.post("/api/v1/jobs/digest/run")
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "success": False,
+        "error_code": "INTERNAL_SERVER_ERROR",
+        "message": "サーバー内部エラーが発生しました",
+    }
+    app.dependency_overrides.clear()
+
+
 def test_get_latest_digest_run_returns_success_response() -> None:
     stub_service = StubRunHistoryService(latest_run=build_digest_run())
     app.dependency_overrides[get_run_history_service] = lambda: stub_service


### PR DESCRIPTION
## 概要
- AppError を共通レスポンスへ変換する API 例外ハンドラを追加
- RequestValidationError を 400 + VALIDATION_ERROR へ統一
- 未処理例外を 500 + INTERNAL_SERVER_ERROR へ統一
- digest API から個別の try/except と手書きエラーレスポンスを削除

## テスト
- python3 -m pytest -q tests/unit/api/test_digest_api.py
- python3 -m pytest -q tests/unit

close #26