### PR TITLE
[T406] OpenAPIメタデータ整備

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,14 @@ from app.core.logging import configure_logging
 from app.db.connection import initialize_database
 from app.schemas.api import ApiErrorResponse
 
+APP_TITLE = "FocusDigest"
+APP_VERSION = "v1"
+APP_DESCRIPTION = (
+    "FocusDigest MVP API. "
+    "ローカル検証用途として、ヘルスチェック、ダイジェスト手動実行、"
+    "最新実行結果取得を提供します。"
+)
+
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
@@ -24,7 +32,12 @@ async def lifespan(_: FastAPI):
     yield
 
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(
+    title=APP_TITLE,
+    version=APP_VERSION,
+    description=APP_DESCRIPTION,
+    lifespan=lifespan,
+)
 app.include_router(health_router)
 app.include_router(digest_router)
 

--- a/tests/unit/api/test_health_api.py
+++ b/tests/unit/api/test_health_api.py
@@ -19,3 +19,24 @@ def test_get_health_returns_common_success_response() -> None:
     assert body["data"]["status"] == "ok"
     assert body["data"]["app_name"] == "FocusDigest"
     datetime.fromisoformat(body["data"]["timestamp"])
+
+
+def test_openapi_metadata_exposes_title_version_description_and_paths() -> None:
+    client = TestClient(app)
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["info"] == {
+        "title": "FocusDigest",
+        "version": "v1",
+        "description": (
+            "FocusDigest MVP API. "
+            "ローカル検証用途として、ヘルスチェック、ダイジェスト手動実行、"
+            "最新実行結果取得を提供します。"
+        ),
+    }
+    assert "/api/v1/health" in body["paths"]
+    assert "/api/v1/jobs/digest/run" in body["paths"]
+    assert "/api/v1/jobs/digest/runs/latest" in body["paths"]


### PR DESCRIPTION
## 概要
- FastAPI アプリに OpenAPI 用の title / version / description を追加
- `/openapi.json` で主要 3 API とメタデータが確認できるテストを追加

## 動作確認
- `PYTHONPATH=. .venv/bin/pytest tests/unit/api/test_health_api.py tests/unit/api/test_digest_api.py`
- `PYTHONPATH=. .venv/bin/pytest -q`
- `.venv/bin/python` と `TestClient` で `/openapi.json` の `info` と `paths` を確認

close #27
