### PR TITLE
[T501] APScheduler初期化実装

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.core.exceptions import AppError
 from app.core.logging import configure_logging
 from app.db.connection import initialize_database
 from app.schemas.api import ApiErrorResponse
+from app.schedulers.digest_scheduler import DigestScheduler
 
 APP_TITLE = "FocusDigest"
 APP_VERSION = "v1"
@@ -24,12 +25,23 @@ APP_DESCRIPTION = (
 )
 
 
+def build_digest_scheduler() -> DigestScheduler:
+    return DigestScheduler()
+
+
 @asynccontextmanager
-async def lifespan(_: FastAPI):
+async def lifespan(app: FastAPI):
     logger = configure_logging()
     initialize_database()
     logger.info("データベースを初期化しました", extra={"run_id": "-"})
-    yield
+    digest_scheduler = build_digest_scheduler()
+    digest_scheduler.start()
+    app.state.digest_scheduler = digest_scheduler
+
+    try:
+        yield
+    finally:
+        digest_scheduler.shutdown()
 
 
 app = FastAPI(

--- a/app/schedulers/digest_scheduler.py
+++ b/app/schedulers/digest_scheduler.py
@@ -1,1 +1,37 @@
 """APScheduler registration logic."""
+
+from __future__ import annotations
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from app.core.logging import get_logger
+
+
+class DigestScheduler:
+    def __init__(self) -> None:
+        self._logger = get_logger("scheduler")
+        self._scheduler = BackgroundScheduler()
+
+    @property
+    def running(self) -> bool:
+        return self._scheduler.running
+
+    def start(self) -> None:
+        if self._scheduler.running:
+            return
+
+        self._scheduler.start()
+        self._logger.info("スケジューラを起動しました", extra={"run_id": "-"})
+
+    def shutdown(self) -> None:
+        if not self._scheduler.running:
+            return
+
+        self._scheduler.shutdown(wait=False)
+        self._logger.info("スケジューラを停止しました", extra={"run_id": "-"})
+
+    def register_jobs(self) -> None:
+        """Register scheduled jobs.
+
+        T501 only starts the scheduler. Job registration is added in T502.
+        """

--- a/tests/unit/schedulers/test_digest_scheduler.py
+++ b/tests/unit/schedulers/test_digest_scheduler.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from app.schedulers.digest_scheduler import DigestScheduler
+
+
+def test_digest_scheduler_start_and_shutdown_manage_running_state() -> None:
+    scheduler = DigestScheduler()
+
+    assert scheduler.running is False
+
+    scheduler.start()
+
+    assert scheduler.running is True
+
+    scheduler.shutdown()
+
+    assert scheduler.running is False

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+class StubLogger:
+    def info(self, *_args, **_kwargs) -> None:
+        pass
+
+
+class StubDigestScheduler:
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def shutdown(self) -> None:
+        self.stopped = True
+
+
+def test_lifespan_starts_and_stops_digest_scheduler(monkeypatch) -> None:
+    stub_scheduler = StubDigestScheduler()
+
+    monkeypatch.setattr("app.main.configure_logging", lambda: StubLogger())
+    monkeypatch.setattr("app.main.initialize_database", lambda: None)
+    monkeypatch.setattr("app.main.build_digest_scheduler", lambda: stub_scheduler)
+
+    with TestClient(app):
+        assert stub_scheduler.started is True
+        assert app.state.digest_scheduler is stub_scheduler
+        assert stub_scheduler.stopped is False
+
+    assert stub_scheduler.stopped is True


### PR DESCRIPTION
## 概要
- FastAPI lifespan に APScheduler の起動・停止処理を追加
- `DigestScheduler` を追加して `BackgroundScheduler` の初期化責務を分離
- スケジューラ起動確認テストと lifespan テストを追加

## 動作確認
- `PYTHONPATH=. .venv/bin/pytest tests/unit/schedulers/test_digest_scheduler.py tests/unit/test_main.py tests/unit/api/test_health_api.py tests/unit/api/test_digest_api.py`
- `PYTHONPATH=. .venv/bin/pytest -q`
- `OPENAI_API_KEY=dummy .venv/bin/python` と `TestClient(app)` で起動し、`DigestScheduler` の `running=True` と shutdown 後の `False` を確認

## レビュー結果
- 機能上の問題は見つかりませんでした
- 実アプリ起動時に既存前提として `OPENAI_API_KEY` が必要です

close #28
