### PR TITLE
[T502] 日次ジョブ登録実装

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from app.api.digest import router as digest_router
+from app.core.config import get_settings
 from app.api.health import router as health_router
 from app.core.exceptions import AppError
 from app.core.logging import configure_logging
@@ -26,7 +27,11 @@ APP_DESCRIPTION = (
 
 
 def build_digest_scheduler() -> DigestScheduler:
-    return DigestScheduler()
+    settings = get_settings()
+    return DigestScheduler(
+        schedule_hour=settings.schedule_hour,
+        schedule_minute=settings.schedule_minute,
+    )
 
 
 @asynccontextmanager
@@ -35,6 +40,7 @@ async def lifespan(app: FastAPI):
     initialize_database()
     logger.info("データベースを初期化しました", extra={"run_id": "-"})
     digest_scheduler = build_digest_scheduler()
+    digest_scheduler.register_jobs()
     digest_scheduler.start()
     app.state.digest_scheduler = digest_scheduler
 

--- a/app/schedulers/digest_scheduler.py
+++ b/app/schedulers/digest_scheduler.py
@@ -2,19 +2,28 @@
 
 from __future__ import annotations
 
+from apscheduler.job import Job
 from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
 
 from app.core.logging import get_logger
 
+DAILY_DIGEST_JOB_ID = "daily_digest"
+
 
 class DigestScheduler:
-    def __init__(self) -> None:
+    def __init__(self, *, schedule_hour: int = 8, schedule_minute: int = 0) -> None:
         self._logger = get_logger("scheduler")
         self._scheduler = BackgroundScheduler()
+        self._schedule_hour = schedule_hour
+        self._schedule_minute = schedule_minute
 
     @property
     def running(self) -> bool:
         return self._scheduler.running
+
+    def get_jobs(self) -> list[Job]:
+        return self._scheduler.get_jobs()
 
     def start(self) -> None:
         if self._scheduler.running:
@@ -31,7 +40,23 @@ class DigestScheduler:
         self._logger.info("スケジューラを停止しました", extra={"run_id": "-"})
 
     def register_jobs(self) -> None:
-        """Register scheduled jobs.
+        self._logger.info("スケジューラジョブ登録を開始します", extra={"run_id": "-"})
 
-        T501 only starts the scheduler. Job registration is added in T502.
-        """
+        if self._scheduler.get_job(DAILY_DIGEST_JOB_ID) is None:
+            self._scheduler.add_job(
+                self._run_scheduled_digest,
+                trigger=CronTrigger(hour=self._schedule_hour, minute=self._schedule_minute),
+                id=DAILY_DIGEST_JOB_ID,
+                replace_existing=False,
+            )
+
+        self._logger.info(
+            "スケジューラジョブ登録が完了しました: id=%s hour=%s minute=%s",
+            DAILY_DIGEST_JOB_ID,
+            self._schedule_hour,
+            self._schedule_minute,
+            extra={"run_id": "-"},
+        )
+
+    def _run_scheduled_digest(self) -> None:
+        """Placeholder for T503, which wires the digest execution."""

--- a/tests/unit/schedulers/test_digest_scheduler.py
+++ b/tests/unit/schedulers/test_digest_scheduler.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from app.schedulers.digest_scheduler import DigestScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from app.schedulers.digest_scheduler import DAILY_DIGEST_JOB_ID, DigestScheduler
 
 
 def test_digest_scheduler_start_and_shutdown_manage_running_state() -> None:
@@ -15,3 +17,27 @@ def test_digest_scheduler_start_and_shutdown_manage_running_state() -> None:
     scheduler.shutdown()
 
     assert scheduler.running is False
+
+
+def test_digest_scheduler_registers_one_daily_job_at_0800() -> None:
+    scheduler = DigestScheduler()
+
+    scheduler.register_jobs()
+
+    jobs = scheduler.get_jobs()
+
+    assert len(jobs) == 1
+    assert jobs[0].id == DAILY_DIGEST_JOB_ID
+    assert isinstance(jobs[0].trigger, CronTrigger)
+    assert str(jobs[0].trigger) == "cron[hour='8', minute='0']"
+
+
+def test_digest_scheduler_does_not_duplicate_registered_job() -> None:
+    scheduler = DigestScheduler()
+
+    scheduler.register_jobs()
+    scheduler.register_jobs()
+
+    jobs = scheduler.get_jobs()
+
+    assert len(jobs) == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -12,8 +12,12 @@ class StubLogger:
 
 class StubDigestScheduler:
     def __init__(self) -> None:
+        self.registered = False
         self.started = False
         self.stopped = False
+
+    def register_jobs(self) -> None:
+        self.registered = True
 
     def start(self) -> None:
         self.started = True
@@ -30,6 +34,7 @@ def test_lifespan_starts_and_stops_digest_scheduler(monkeypatch) -> None:
     monkeypatch.setattr("app.main.build_digest_scheduler", lambda: stub_scheduler)
 
     with TestClient(app):
+        assert stub_scheduler.registered is True
         assert stub_scheduler.started is True
         assert app.state.digest_scheduler is stub_scheduler
         assert stub_scheduler.stopped is False


### PR DESCRIPTION
## 概要
- `DigestScheduler` に毎日 08:00 の cron ジョブ登録を追加
- 同一ジョブIDの重複登録を防止
- アプリ起動時に `register_jobs()` が呼ばれるように変更
- ジョブ登録テストと起動時登録テストを追加

## 動作確認
- `PYTHONPATH=. .venv/bin/pytest tests/unit/schedulers/test_digest_scheduler.py tests/unit/test_main.py tests/unit/api/test_health_api.py tests/unit/api/test_digest_api.py`
- `PYTHONPATH=. .venv/bin/pytest -q`
- `OPENAI_API_KEY=dummy .venv/bin/python` と `TestClient(app)` で起動し、ジョブ一覧が 1 件、`id=daily_digest`、`cron[hour='8', minute='0']` であることを確認

## レビュー結果
- T502 のスコープ内で機能上の問題は見つかりませんでした
- issue #29 の「scheduler起点の実行履歴が残る」は T503 の責務であり、本PRでは未実装です

close #29
