### PR TITLE
[T503] scheduler実行連携

### DIFF
--- a/app/api/digest.py
+++ b/app/api/digest.py
@@ -27,7 +27,7 @@ def get_run_history_service() -> RunHistoryService:
     return RunHistoryService(DigestRunRepository())
 
 
-def get_digest_service(settings: Settings = Depends(get_settings)) -> DigestService:
+def build_digest_service(settings: Settings) -> DigestService:
     article_repository = ArticleRepository()
 
     return DigestService(
@@ -42,6 +42,10 @@ def get_digest_service(settings: Settings = Depends(get_settings)) -> DigestServ
         mail_service=MailService(settings=settings),
         run_history_service=RunHistoryService(DigestRunRepository()),
     )
+
+
+def get_digest_service(settings: Settings = Depends(get_settings)) -> DigestService:
+    return build_digest_service(settings)
 @router.post("/jobs/digest/run", response_model=ApiSuccessResponse[DigestRunData])
 def run_digest_job(
     payload: dict[str, Any] | None = Body(default=None),

--- a/app/main.py
+++ b/app/main.py
@@ -8,9 +8,9 @@ from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
-from app.api.digest import router as digest_router
-from app.core.config import get_settings
+from app.api.digest import build_digest_service, router as digest_router
 from app.api.health import router as health_router
+from app.core.config import Settings, get_settings
 from app.core.exceptions import AppError
 from app.core.logging import configure_logging
 from app.db.connection import initialize_database
@@ -31,7 +31,13 @@ def build_digest_scheduler() -> DigestScheduler:
     return DigestScheduler(
         schedule_hour=settings.schedule_hour,
         schedule_minute=settings.schedule_minute,
+        run_digest_job=lambda: run_scheduled_digest(settings),
     )
+
+
+def run_scheduled_digest(settings: Settings) -> None:
+    digest_service = build_digest_service(settings)
+    digest_service.run("scheduler")
 
 
 @asynccontextmanager

--- a/app/schedulers/digest_scheduler.py
+++ b/app/schedulers/digest_scheduler.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Callable
+
 from apscheduler.job import Job
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -12,11 +14,18 @@ DAILY_DIGEST_JOB_ID = "daily_digest"
 
 
 class DigestScheduler:
-    def __init__(self, *, schedule_hour: int = 8, schedule_minute: int = 0) -> None:
+    def __init__(
+        self,
+        *,
+        schedule_hour: int = 8,
+        schedule_minute: int = 0,
+        run_digest_job: Callable[[], None] | None = None,
+    ) -> None:
         self._logger = get_logger("scheduler")
         self._scheduler = BackgroundScheduler()
         self._schedule_hour = schedule_hour
         self._schedule_minute = schedule_minute
+        self._run_digest_job = run_digest_job or (lambda: None)
 
     @property
     def running(self) -> bool:
@@ -59,4 +68,14 @@ class DigestScheduler:
         )
 
     def _run_scheduled_digest(self) -> None:
-        """Placeholder for T503, which wires the digest execution."""
+        self._logger.info("スケジューラ起点のダイジェスト処理を開始します", extra={"run_id": "-"})
+        try:
+            self._run_digest_job()
+        except Exception:
+            self._logger.exception(
+                "スケジューラ起点のダイジェスト処理に失敗しました",
+                extra={"run_id": "-"},
+            )
+            raise
+
+        self._logger.info("スケジューラ起点のダイジェスト処理が完了しました", extra={"run_id": "-"})

--- a/tests/unit/schedulers/test_digest_scheduler.py
+++ b/tests/unit/schedulers/test_digest_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from apscheduler.triggers.cron import CronTrigger
+import pytest
 
 from app.schedulers.digest_scheduler import DAILY_DIGEST_JOB_ID, DigestScheduler
 
@@ -41,3 +42,26 @@ def test_digest_scheduler_does_not_duplicate_registered_job() -> None:
     jobs = scheduler.get_jobs()
 
     assert len(jobs) == 1
+
+
+def test_digest_scheduler_runs_digest_job_with_scheduler_trigger() -> None:
+    calls: list[str] = []
+
+    def run_digest_job() -> None:
+        calls.append("called")
+
+    scheduler = DigestScheduler(run_digest_job=run_digest_job)
+
+    scheduler._run_scheduled_digest()
+
+    assert calls == ["called"]
+
+
+def test_digest_scheduler_reraises_digest_job_errors() -> None:
+    def run_digest_job() -> None:
+        raise RuntimeError("boom")
+
+    scheduler = DigestScheduler(run_digest_job=run_digest_job)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        scheduler._run_scheduled_digest()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -40,3 +40,30 @@ def test_lifespan_starts_and_stops_digest_scheduler(monkeypatch) -> None:
         assert stub_scheduler.stopped is False
 
     assert stub_scheduler.stopped is True
+
+
+class StubDigestService:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def run(self, triggered_by: str) -> None:
+        self.calls.append(triggered_by)
+
+
+def test_run_scheduled_digest_uses_digest_service_with_scheduler_trigger(monkeypatch) -> None:
+    settings = object()
+    stub_service = StubDigestService()
+    build_calls: list[object] = []
+
+    def fake_build_digest_service(received_settings: object) -> StubDigestService:
+        build_calls.append(received_settings)
+        return stub_service
+
+    monkeypatch.setattr("app.main.build_digest_service", fake_build_digest_service)
+
+    from app.main import run_scheduled_digest
+
+    run_scheduled_digest(settings)  # type: ignore[arg-type]
+
+    assert build_calls == [settings]
+    assert stub_service.calls == ["scheduler"]


### PR DESCRIPTION
## 概要
- scheduler から `DigestService.run("scheduler")` を呼べるように実行連携を追加
- API と scheduler で同じ `DigestService` 構築経路を使うように整理
- scheduler 実行コールバックと main 側の結線テストを追加

## 動作確認
- `PYTHONPATH=. .venv/bin/pytest tests/unit/schedulers/test_digest_scheduler.py tests/unit/test_main.py tests/unit/api/test_health_api.py tests/unit/api/test_digest_api.py`
- `PYTHONPATH=. .venv/bin/pytest -q`
- `OPENAI_API_KEY=dummy .venv/bin/python` から `run_scheduled_digest(get_settings())` を直接呼び出し、その後 `sqlite3 data/app.db "select id, triggered_by, email_status, error_message from digest_runs order by id desc limit 3;"` で最新レコードが `triggered_by=scheduler` で記録されることを確認

## レビュー結果
- T503 のスコープ内で機能上の問題は見つかりませんでした
- scheduler 実行は `DigestService` の既存ロックを使うため、手動実行との同時実行防止も継続されます

close #30
