### PR TITLE
[T603] NewsService単体テスト

### DIFF
--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -22,9 +22,17 @@ class NewsService:
         return [article for article in articles if self._is_valid_article(article)]
 
     def _is_valid_article(self, article: ArticleFetchResult) -> bool:
-        if article.title is None or article.url is None or article.published_at is None:
+        if not self._has_text(article.title):
+            return False
+        if not self._has_text(article.url):
+            return False
+        if not self._has_text(article.published_at):
             return False
         return self._is_valid_iso8601(article.published_at)
+
+    @staticmethod
+    def _has_text(value: str | None) -> bool:
+        return value is not None and value.strip() != ""
 
     @staticmethod
     def _is_valid_iso8601(value: str) -> bool:

--- a/tests/unit/services/test_news_service.py
+++ b/tests/unit/services/test_news_service.py
@@ -87,3 +87,48 @@ def test_fetch_latest_articles_filters_invalid_published_at() -> None:
 
     assert len(results) == 1
     assert results[0].published_at == "2026-04-25T09:00:00Z"
+
+
+def test_fetch_latest_articles_filters_blank_required_fields() -> None:
+    client = DummyNewsClient(
+        [
+            ArticleFetchResult(
+                title="  ",
+                description="タイトルが空白のみ",
+                url="https://example.com/articles/1",
+                published_at="2026-04-25T09:00:00Z",
+                source_name="Example News",
+                category="AI",
+            ),
+            ArticleFetchResult(
+                title="URL空白",
+                description="URLが空白のみ",
+                url="   ",
+                published_at="2026-04-25T10:00:00Z",
+                source_name="Example News",
+                category="AI",
+            ),
+            ArticleFetchResult(
+                title="公開日時空白",
+                description="published_at が空白のみ",
+                url="https://example.com/articles/3",
+                published_at="   ",
+                source_name="Example News",
+                category="AI",
+            ),
+            ArticleFetchResult(
+                title="正常記事",
+                description="正常データ",
+                url="https://example.com/articles/4",
+                published_at="2026-04-25T11:00:00Z",
+                source_name="Example News",
+                category="AI",
+            ),
+        ]
+    )
+    service = NewsService(client)
+
+    results = service.fetch_latest_articles("AI", 20)
+
+    assert len(results) == 1
+    assert results[0].url == "https://example.com/articles/4"


### PR DESCRIPTION
## 概要
- NewsService 単体テストに、必須項目が空白-only の記事を除外するケースを追加
- service 側でも `title`、`url`、`published_at` の空白-only 値を無効扱いするよう補強

## 動作確認
- `PYTHONPATH=. .venv/bin/pytest tests/unit/services/test_news_service.py`
- `PYTHONPATH=. .venv/bin/pytest -q`

## レビュー結果
- T603 のスコープ内で問題は見つかりませんでした
- 外部依存はダミークライアントでモック化されており、再現性を保てています

close #33
