### PR TITLE
[T604] SummaryService単体テスト

### DIFF
--- a/app/services/summary_service.py
+++ b/app/services/summary_service.py
@@ -45,6 +45,8 @@ class SummaryService:
 
             try:
                 summary = self._openai_client.summarize(article.title, article.description)
+                if summary.strip() == "":
+                    raise ExternalApiError("要約結果が空です")
                 updated_article = self._article_repository.update_summary(
                     article.article_id,
                     summary=summary,

--- a/tests/unit/services/test_summary_service.py
+++ b/tests/unit/services/test_summary_service.py
@@ -128,3 +128,16 @@ def test_summarize_articles_skips_articles_with_blank_title() -> None:
     assert results == []
     assert openai_client.calls == []
     assert repository.updates == []
+
+
+def test_summarize_articles_marks_failed_when_summary_is_blank() -> None:
+    article = build_article(1)
+    repository = DummyArticleRepository({1: article})
+    openai_client = DummyOpenAIClient({1: "   "})
+    service = SummaryService(openai_client=openai_client, article_repository=repository)
+
+    results = service.summarize_articles(1, [article])
+
+    assert results == []
+    assert openai_client.calls == [("記事タイトル", "説明文")]
+    assert repository.updates == [(1, None, "failed")]


### PR DESCRIPTION
## 概要
- SummaryService に空文字 / 空白-only の要約結果を失敗扱いにする分岐を追加
- 対応する unit test を追加し、`summary_status=failed` 更新を確認

## 動作確認
- `PYTHONPATH=. .venv/bin/pytest tests/unit/services/test_summary_service.py`
- `PYTHONPATH=. .venv/bin/pytest -q`

## レビュー結果
- T604 のスコープ内で問題は見つかりませんでした
- 外部依存はダミークライアントとダミーrepositoryでモック化されており、再現性を保てています

close #34
