### PR TITLE
[T605] MailService単体テスト

### DIFF
--- a/app/services/mail_service.py
+++ b/app/services/mail_service.py
@@ -54,6 +54,10 @@ class MailService:
 
     def send_mail(self, subject: str, body: str) -> None:
         self._validate_smtp_settings()
+        if subject.strip() == "":
+            raise MailBuildError("メール件名の生成に失敗しました")
+        if body.strip() == "":
+            raise MailBuildError("メール本文の生成に失敗しました")
         smtp_client = self._smtp_client_factory(
             host=self._settings.smtp_host,
             port=self._settings.smtp_port,

--- a/tests/unit/services/test_mail_service.py
+++ b/tests/unit/services/test_mail_service.py
@@ -108,6 +108,20 @@ def test_send_mail_raises_configuration_error_when_smtp_password_is_missing() ->
         service.send_mail("件名", "本文")
 
 
+def test_send_mail_raises_mail_build_error_when_body_is_blank() -> None:
+    service = MailService(settings=build_settings())
+
+    with pytest.raises(MailBuildError, match="メール本文の生成に失敗しました"):
+        service.send_mail("件名", "   ")
+
+
+def test_send_mail_raises_mail_build_error_when_subject_is_blank() -> None:
+    service = MailService(settings=build_settings())
+
+    with pytest.raises(MailBuildError, match="メール件名の生成に失敗しました"):
+        service.send_mail("   ", "本文")
+
+
 def test_send_mail_uses_smtp_client_when_settings_are_complete() -> None:
     created_clients: list[DummySmtpClient] = []
 


### PR DESCRIPTION
## 概要
- MailService に空件名・空本文の事前バリデーションを追加
- 対応する unit test を追加し、件名、本文、空本文禁止を明示的に確認

## 動作確認
- `PYTHONPATH=. .venv/bin/pytest tests/unit/services/test_mail_service.py`
- `PYTHONPATH=. .venv/bin/pytest -q`

## レビュー結果
- T605 のスコープ内で問題は見つかりませんでした
- 外部依存はダミー SMTP クライアントでモック化されており、再現性を保てています

close #35
