### PR TITLE
[T701] Add Dockerfile for app startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+.pytest_cache
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+data
+logs
+tests
+docoments

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+RUN mkdir -p /app/data /app/logs
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs runtime dependencies and starts the FastAPI app with uvicorn
- add a .dockerignore to keep local env, logs, test files, and design docs out of the build context
- verify Docker build, container startup, health check response, and startup logs

## Testing
- python3 -m pytest tests/unit/test_main.py tests/unit/schedulers/test_digest_scheduler.py
- docker build -t focusdigest:t701 .
- docker run --env-file .env -p 8000:8000 -v "/Users/fumikun.wen/Desktop/03_project/AINewsDigestApp-mvp/data:/app/data" -v "/Users/fumikun.wen/Desktop/03_project/AINewsDigestApp-mvp/logs:/app/logs" focusdigest:t701
- curl http://localhost:8000/api/v1/health

close #39