### PR TITLE
[T702] Add startup and verification guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,34 +82,11 @@ requirements-dev.txt
 補足:
 
 - 設計資料ディレクトリ名は `documents` ではなく `docoments` です
-- 現時点ではコードの多くが雛形段階で、設計書が先行しています
-
-## 現状ステータス
-
-2026-04-18 時点では、リポジトリは主に設計資料と Python パッケージ雛形で構成されています。
-
-実装済み:
-
-- ディレクトリ構成
-- 依存ライブラリ定義
-- 各モジュールのプレースホルダファイル
-- 設計書、要件定義、API 仕様、DB 設計、実装手順書
-
-未実装または未着手:
-
-- FastAPI エンドポイント本体
-- 設定読み込み
-- DB 初期化
-- TheNewsAPI / OpenAI / SMTP クライアント
-- 業務サービス
-- スケジューラ実処理
-- テストコード
-- Dockerfile
-- `.env.example`
+- 実行手順の詳細は [起動手順書.md](./起動手順書.md) にまとめています
 
 ## 必要な環境変数
 
-設計資料上、以下の設定を利用する前提です。
+以下の設定を利用します。
 
 ```env
 CATEGORY=AI
@@ -119,6 +96,7 @@ SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USERNAME=your_gmail_address
 SMTP_PASSWORD=your_app_password
+MAIL_TO_ADDRESS=recipient@example.com
 ```
 
 補足:
@@ -126,7 +104,8 @@ SMTP_PASSWORD=your_app_password
 - `CATEGORY` は 2 文字以上 50 文字以内を想定
 - SMTP は Gmail 前提で設計されています
 - 互換性のため `NEWS_API_KEY` でも読み込めますが、新規設定は `THE_NEWS_API_TOKEN` を推奨します
-- 現在は `.env.example` が未作成です
+- `MAIL_FROM_ADDRESS` は未指定時に `SMTP_USERNAME` が使われます
+- `DB_PATH`、`LOG_PATH`、`FETCH_LIMIT`、`SELECTION_LIMIT`、`SCHEDULE_HOUR`、`SCHEDULE_MINUTE` は任意です
 
 ## セットアップ
 
@@ -150,18 +129,31 @@ pip install -r requirements-dev.txt
 
 ## 実行方法
 
-アプリ本体はまだ未実装のため、現時点ではそのまま起動しても API やバッチ処理は動作しません。  
-今後の想定実行方法は以下です。
+ローカル起動:
 
 ```bash
-uvicorn app.main:app --reload
+uvicorn app.main:app --host 0.0.0.0 --port 8000
 ```
 
-想定される確認ポイント:
+Docker 起動:
+
+```bash
+docker build -t focusdigest:local .
+docker run --rm \
+  --env-file .env \
+  -p 8000:8000 \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/logs:/app/logs" \
+  focusdigest:local
+```
+
+主要な確認ポイント:
 
 - `GET /api/v1/health`
 - `POST /api/v1/jobs/digest/run`
 - `GET /api/v1/jobs/digest/runs/latest`
+
+手動実行 API はボディなし、空ボディ、または空 JSON で呼び出せます。
 
 ## データ保存とログ
 
@@ -187,17 +179,3 @@ Docker 利用時は、設計上は以下のようなホストマウントを想�
 - `docoments/API仕様書.md`
 - `docoments/データベース設計書.md`
 - `docoments/実装手順書.md`
-
-## 次に着手すべき項目
-
-優先度順の候補:
-
-1. `app/core/config.py` の設定管理実装
-2. `app/db/connection.py` と `app/db/schema.sql` の DB 初期化実装
-3. 外部 API / SMTP クライアント実装
-4. サービス層実装
-5. FastAPI エンドポイント実装
-6. APScheduler 連携
-7. テスト追加
-8. Dockerfile と `.env.example` 追加
-

--- a/起動手順書.md
+++ b/起動手順書.md
@@ -1,0 +1,161 @@
+# FocusDigest 起動手順書
+
+## 目的
+
+この文書は、第三者が FocusDigest をローカルまたは Docker で起動し、ヘルスチェック、手動実行、最新実行結果取得まで再現するための手順をまとめたものです。
+
+## 前提
+
+- macOS または Linux 環境でコマンド実行できること
+- `.env` に必要な環境変数を設定済みであること
+- Docker 利用時は `docker` コマンドと daemon が利用可能であること
+
+## 必須環境変数
+
+`.env` に以下を設定します。
+
+```env
+CATEGORY=AI
+THE_NEWS_API_TOKEN=your_thenewsapi_token
+OPENAI_API_KEY=your_openai_api_key
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USERNAME=your_gmail_address
+SMTP_PASSWORD=your_app_password
+MAIL_TO_ADDRESS=recipient@example.com
+```
+
+補足:
+
+- `MAIL_FROM_ADDRESS` を省略した場合は `SMTP_USERNAME` が使われます
+- Gmail を使う場合は通常のログインパスワードではなくアプリパスワードを使用します
+- `DB_PATH` と `LOG_PATH` を省略した場合はローカル起動で `data/app.db`、`logs/app.log` が使われます
+
+## ローカル起動
+
+### 1. 依存関係をインストールする
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+### 2. アプリを起動する
+
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+### 3. ヘルスチェックを確認する
+
+```bash
+curl http://localhost:8000/api/v1/health
+```
+
+期待結果:
+
+- HTTP 200
+- `success=true`
+- `data.status=ok`
+- `data.app_name=FocusDigest`
+
+### 4. 手動実行 API を確認する
+
+空 JSON で呼ぶ場合:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/jobs/digest/run \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+ボディなしで呼ぶ場合:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/jobs/digest/run
+```
+
+期待結果:
+
+- HTTP 200
+- `data.run_id`
+- `data.triggered_by=manual`
+- `data.fetched_count`
+- `data.selected_count`
+- `data.summarized_count`
+- `data.email_status`
+
+### 5. 最新実行結果を確認する
+
+```bash
+curl http://localhost:8000/api/v1/jobs/digest/runs/latest
+```
+
+## Docker 起動
+
+### 1. イメージをビルドする
+
+```bash
+docker build -t focusdigest:local .
+```
+
+### 2. 永続化ディレクトリを作成する
+
+```bash
+mkdir -p data logs
+```
+
+### 3. コンテナを起動する
+
+```bash
+docker run --rm \
+  --env-file .env \
+  -p 8000:8000 \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/logs:/app/logs" \
+  focusdigest:local
+```
+
+補足:
+
+- SQLite は `/app/data/app.db` に保存されます
+- ログは `/app/logs/app.log` に出力されます
+- Docker では `./data:/app/data` と `./logs:/app/logs` のホストマウントを前提にしています
+
+### 4. 動作確認を行う
+
+ヘルスチェック:
+
+```bash
+curl http://localhost:8000/api/v1/health
+```
+
+手動実行 API:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/jobs/digest/run \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+最新実行結果 API:
+
+```bash
+curl http://localhost:8000/api/v1/jobs/digest/runs/latest
+```
+
+## 確認ポイント
+
+- `data/app.db` が作成または更新されること
+- `logs/app.log` に起動ログが出ること
+- スケジューラ登録ログが出ること
+- 手動実行 API のレスポンスに `run_id` と件数項目が含まれること
+
+## 代表的な失敗時の確認箇所
+
+- 設定不備: `.env`
+- DB 書込失敗: `data/` の権限とマウント先
+- ログ確認: `logs/app.log`
+- Docker daemon 停止: `docker info`


### PR DESCRIPTION
## Summary
- add a dedicated startup guide for local and Docker usage
- update the README to reflect current runtime behavior and link to the detailed guide
- document required env vars, host mounts, health checks, manual run steps, and troubleshooting points

## Review
- reviewed README and 起動手順書 for env var / API path consistency with app/core/config.py
- no findings

## Testing
- docker build -t focusdigest:t702-docs .
- python3 -m pytest tests/unit/test_main.py tests/unit/schedulers/test_digest_scheduler.py

close #40