### PR TITLE
Fix scheduler timezone to Asia/Tokyo

### DIFF
--- a/app/schedulers/digest_scheduler.py
+++ b/app/schedulers/digest_scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Callable
+from zoneinfo import ZoneInfo
 
 from apscheduler.job import Job
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -11,6 +12,7 @@ from apscheduler.triggers.cron import CronTrigger
 from app.core.logging import get_logger
 
 DAILY_DIGEST_JOB_ID = "daily_digest"
+SCHEDULER_TIMEZONE = ZoneInfo("Asia/Tokyo")
 
 
 class DigestScheduler:
@@ -22,7 +24,7 @@ class DigestScheduler:
         run_digest_job: Callable[[], None] | None = None,
     ) -> None:
         self._logger = get_logger("scheduler")
-        self._scheduler = BackgroundScheduler()
+        self._scheduler = BackgroundScheduler(timezone=SCHEDULER_TIMEZONE)
         self._schedule_hour = schedule_hour
         self._schedule_minute = schedule_minute
         self._run_digest_job = run_digest_job or (lambda: None)
@@ -54,7 +56,11 @@ class DigestScheduler:
         if self._scheduler.get_job(DAILY_DIGEST_JOB_ID) is None:
             self._scheduler.add_job(
                 self._run_scheduled_digest,
-                trigger=CronTrigger(hour=self._schedule_hour, minute=self._schedule_minute),
+                trigger=CronTrigger(
+                    hour=self._schedule_hour,
+                    minute=self._schedule_minute,
+                    timezone=SCHEDULER_TIMEZONE,
+                ),
                 id=DAILY_DIGEST_JOB_ID,
                 replace_existing=False,
             )

--- a/tests/unit/schedulers/test_digest_scheduler.py
+++ b/tests/unit/schedulers/test_digest_scheduler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from apscheduler.triggers.cron import CronTrigger
 import pytest
 
-from app.schedulers.digest_scheduler import DAILY_DIGEST_JOB_ID, DigestScheduler
+from app.schedulers.digest_scheduler import DAILY_DIGEST_JOB_ID, DigestScheduler, SCHEDULER_TIMEZONE
 
 
 def test_digest_scheduler_start_and_shutdown_manage_running_state() -> None:
@@ -31,6 +31,7 @@ def test_digest_scheduler_registers_one_daily_job_at_0800() -> None:
     assert jobs[0].id == DAILY_DIGEST_JOB_ID
     assert isinstance(jobs[0].trigger, CronTrigger)
     assert str(jobs[0].trigger) == "cron[hour='8', minute='0']"
+    assert jobs[0].trigger.timezone == SCHEDULER_TIMEZONE
 
 
 def test_digest_scheduler_does_not_duplicate_registered_job() -> None:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 from app.core.config import Settings
-from app.schedulers.digest_scheduler import DAILY_DIGEST_JOB_ID
+from app.schedulers.digest_scheduler import DAILY_DIGEST_JOB_ID, SCHEDULER_TIMEZONE
 
 
 class StubLogger:
@@ -76,6 +76,7 @@ def test_build_digest_scheduler_registers_one_job_with_configured_schedule(monke
     assert jobs[0].id == DAILY_DIGEST_JOB_ID
     assert isinstance(jobs[0].trigger, CronTrigger)
     assert str(jobs[0].trigger) == "cron[hour='9', minute='30']"
+    assert jobs[0].trigger.timezone == SCHEDULER_TIMEZONE
     scheduler.shutdown()
 
 


### PR DESCRIPTION
## Summary
- set APScheduler's background scheduler timezone to `Asia/Tokyo`
- set the cron trigger timezone explicitly to `Asia/Tokyo`
- update scheduler-related tests to assert the configured timezone
